### PR TITLE
[ACM-8903] Added ROSA-HCP transform for clustertype MOA-HostedControlPlane

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+# Description
+
+Please provide a brief description of the purpose of this pull request.
+
+## Related Issue
+
+If applicable, please reference the issue(s) that this pull request addresses.
+
+## Changes Made
+
+Provide a clear and concise overview of the changes made in this pull request.
+
+## Screenshots (if applicable)
+
+Add screenshots or GIFs that demonstrate the changes visually, if relevant.
+
+## Checklist
+
+- [ ] I have tested the changes locally and they are functioning as expected.
+- [ ] I have updated the documentation (if necessary) to reflect the changes.
+- [ ] I have added/updated relevant unit tests (if applicable).
+- [ ] I have ensured that my code follows the project's coding standards.
+- [ ] I have checked for any potential security issues and addressed them.
+- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
+- [ ] I have rebased my branch on top of the latest main/master branch.
+
+## Additional Notes
+
+Add any additional notes, context, or information that might be helpful for reviewers.
+
+## Reviewers
+
+Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`
+
+## Definition of Done
+
+- [ ] Code is reviewed.
+- [ ] Code is tested.
+- [ ] Documentation is updated.
+- [ ] All checks and tests pass.
+- [ ] Approved by at least one reviewer.
+- [ ] Merged into the main/master branch.

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -137,11 +137,17 @@ func computeApiUrl(sub subscription.Subscription) string {
 
 // computeType calculates the type of the cluster based on subscription.plan.id
 func computeType(sub subscription.Subscription) string {
+	var clusterType string
 
-	clusterType := sub.Plan.ID
-
-	if clusterType == "MOA" { // API returns MOA but this is displayed in OCM as ROSA
+	switch sub.Plan.ID {
+	case "MOA": // API returns MOA but this is displayed in OCM as ROSA
 		clusterType = "ROSA"
+
+	case "MOA-HostedControlPlane":
+		clusterType = "ROSA-HCP"
+
+	default:
+		clusterType = sub.Plan.ID
 	}
 
 	return clusterType

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -137,18 +137,11 @@ func computeApiUrl(sub subscription.Subscription) string {
 
 // computeType calculates the type of the cluster based on subscription.plan.id
 func computeType(sub subscription.Subscription) string {
-	var clusterType string
-
 	switch sub.Plan.ID {
-	case "MOA": // API returns MOA but this is displayed in OCM as ROSA
-		clusterType = "ROSA"
-
-	case "MOA-HostedControlPlane":
-		clusterType = "ROSA-HCP"
+	case "MOA", "MOA-HostedControlPlane": // API returns MOA but this is displayed in OCM as ROSA
+		return "ROSA"
 
 	default:
-		clusterType = sub.Plan.ID
+		return sub.Plan.ID
 	}
-
-	return clusterType
 }


### PR DESCRIPTION
# Description

Adding a type mapping for `MOA-HostedControlPlane`. Currently, within the UI the discovered cluster is shown as `MOA-HostedControlPlane`, which is not the desire type for the console.

## Related Issue

https://issues.redhat.com/browse/ACM-8903

## Changes Made

When the clustertype `MOA-HostedControlPlane` is detected, the discovery operator will transform the clustertype to `ROSA-HCP`. 

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
