### PR TITLE
[ACM-10305] Updated DiscoveredCluster CRD spec to support enableAutoImport field

### DIFF
--- a/api/v1/discoveredcluster_types.go
+++ b/api/v1/discoveredcluster_types.go
@@ -44,21 +44,23 @@ const (
 
 // DiscoveredClusterSpec defines the desired state of DiscoveredCluster
 type DiscoveredClusterSpec struct {
-	Name              string       `json:"name" yaml:"name"`
-	DisplayName       string       `json:"displayName" yaml:"displayName"`
-	OCPClusterID      string       `json:"ocpClusterId,omitempty" yaml:"ocpClusterId,omitempty"`
-	RHOCMClusterID    string       `json:"rhocmClusterId,omitempty" yaml:"rhocmClusterId,omitempty"`
-	Console           string       `json:"console,omitempty" yaml:"console,omitempty"`
-	APIURL            string       `json:"apiUrl" yaml:"apiUrl"`
-	CreationTimestamp *metav1.Time `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
-	ActivityTimestamp *metav1.Time `json:"activityTimestamp,omitempty" yaml:"activityTimestamp,omitempty"`
-	Type              string       `json:"type" yaml:"type"`
-	OpenshiftVersion  string       `json:"openshiftVersion,omitempty" yaml:"openshiftVersion,omitempty"`
-	CloudProvider     string       `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`
-	Status            string       `json:"status,omitempty" yaml:"status,omitempty"`
-	IsManagedCluster  bool         `json:"isManagedCluster" yaml:"isManagedCluster"`
-
-	Credential corev1.ObjectReference `json:"credential,omitempty" yaml:"credential,omitempty"`
+	ActivityTimestamp *metav1.Time           `json:"activityTimestamp,omitempty" yaml:"activityTimestamp,omitempty"`
+	APIURL            string                 `json:"apiUrl" yaml:"apiUrl"`
+	CloudProvider     string                 `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`
+	Console           string                 `json:"console,omitempty" yaml:"console,omitempty"`
+	CreationTimestamp *metav1.Time           `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
+	Credential        corev1.ObjectReference `json:"credential,omitempty" yaml:"credential,omitempty"`
+	DisplayName       string                 `json:"displayName" yaml:"displayName"`
+	EnableAutoImport  bool                   `json:"enableAutoImport,omitempty" yaml:"enableAutoImport,omitempty"`
+	IsManagedCluster  bool                   `json:"isManagedCluster" yaml:"isManagedCluster"`
+	Name              string                 `json:"name" yaml:"name"`
+	OCPClusterID      string                 `json:"ocpClusterId,omitempty" yaml:"ocpClusterId,omitempty"`
+	OpenshiftVersion  string                 `json:"openshiftVersion,omitempty" yaml:"openshiftVersion,omitempty"`
+	Owner             string                 `json:"owner,omitempty" yaml:"owner,omitempty"`
+	RHOCMClusterID    string                 `json:"rhocmClusterId,omitempty" yaml:"rhocmClusterId,omitempty"`
+	Region            string                 `json:"region,omitempty" yaml:"region,omitempty"`
+	Status            string                 `json:"status,omitempty" yaml:"status,omitempty"`
+	Type              string                 `json:"type" yaml:"type"`
 }
 
 // DiscoveredClusterStatus defines the observed state of DiscoveredCluster
@@ -95,18 +97,21 @@ func init() {
 
 // Equal reports whether the spec of a is equal to b.
 func (a DiscoveredCluster) Equal(b DiscoveredCluster) bool {
-	if a.Spec.Name != b.Spec.Name ||
-		a.Spec.DisplayName != b.Spec.DisplayName ||
-		a.Spec.Console != b.Spec.Console ||
-		a.Spec.APIURL != b.Spec.APIURL ||
-		a.Spec.CreationTimestamp.Truncate(time.Second) != b.Spec.CreationTimestamp.Truncate(time.Second) ||
+	if a.Spec.APIURL != b.Spec.APIURL ||
 		a.Spec.ActivityTimestamp.Truncate(time.Second) != b.Spec.ActivityTimestamp.Truncate(time.Second) ||
-		a.Spec.Type != b.Spec.Type ||
-		a.Spec.OpenshiftVersion != b.Spec.OpenshiftVersion ||
 		a.Spec.CloudProvider != b.Spec.CloudProvider ||
-		a.Spec.Status != b.Spec.Status ||
+		a.Spec.Console != b.Spec.Console ||
+		a.Spec.CreationTimestamp.Truncate(time.Second) != b.Spec.CreationTimestamp.Truncate(time.Second) ||
+		a.Spec.Credential != b.Spec.Credential ||
+		a.Spec.DisplayName != b.Spec.DisplayName ||
+		a.Spec.EnableAutoImport != b.Spec.EnableAutoImport ||
 		a.Spec.IsManagedCluster != b.Spec.IsManagedCluster ||
-		a.Spec.Credential != b.Spec.Credential {
+		a.Spec.Name != b.Spec.Name ||
+		a.Spec.OpenshiftVersion != b.Spec.OpenshiftVersion ||
+		a.Spec.Owner != b.Spec.Owner ||
+		a.Spec.Region != b.Spec.Region ||
+		a.Spec.Status != b.Spec.Status ||
+		a.Spec.Type != b.Spec.Type {
 		return false
 	}
 	return true

--- a/bundle/manifests/discovery.clusterserviceversion.yaml
+++ b/bundle/manifests/discovery.clusterserviceversion.yaml
@@ -174,6 +174,14 @@ spec:
           - managedclusters/accept
           verbs:
           - update
+        - apiGroups:
+            - apiextensions.k8s.io
+          resources:
+            - customresourcedefinitions
+          verbs:
+            - get
+            - list
+            - watch
         serviceAccountName: discovery-operator
       deployments:
       - label:

--- a/bundle/manifests/discovery.open-cluster-management.io_discoveredclusters.yaml
+++ b/bundle/manifests/discovery.open-cluster-management.io_discoveredclusters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: discoveredclusters.discovery.open-cluster-management.io
 spec:
@@ -41,39 +41,36 @@ spec:
                 type: string
               cloudProvider:
                 type: string
-              ocpClusterId:
-                type: string
-              rhocmClusterId:
-                type: string
               console:
                 type: string
               creationTimestamp:
                 format: date-time
                 type: string
               credential:
-                description: 'ObjectReference contains enough information to let you
+                description: "ObjectReference contains enough information to let you
                   inspect or modify the referred object. --- New uses of this type
                   are discouraged because of difficulty describing its usage when
                   embedded in APIs. 1. Ignored fields.  It includes many fields which
                   are not generally honored.  For instance, ResourceVersion and FieldPath
-                  are both very rarely valid in actual usage. 2. Invalid usage help.  It
-                  is impossible to add specific help for individual usage.  In most
-                  embedded usages, there are particular restrictions like, "must refer
-                  only to types A and B" or "UID not honored" or "name must be restricted".
-                  Those cannot be well described when embedded. 3. Inconsistent validation.  Because
-                  the usages are different, the validation rules are different by
-                  usage, which makes it hard for users to predict what will happen.
-                  4. The fields are both imprecise and overly precise.  Kind is not
-                  a precise mapping to a URL. This can produce ambiguity during interpretation
-                  and require a REST mapping.  In most cases, the dependency is on
-                  the group,resource tuple and the version of the actual struct is
-                  irrelevant. 5. We cannot easily change it.  Because this type is
-                  embedded in many locations, updates to this type will affect numerous
-                  schemas.  Don''t make new APIs embed an underspecified API type
-                  they do not control. Instead of using this type, create a locally
-                  provided and used type that is well-focused on your reference. For
-                  example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                  .'
+                  are both very rarely valid in actual usage. 2. Invalid usage help.
+                  \ It is impossible to add specific help for individual usage.  In
+                  most embedded usages, there are particular restrictions like, \"must
+                  refer only to types A and B\" or \"UID not honored\" or \"name must
+                  be restricted\". Those cannot be well described when embedded. 3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen. 4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity during interpretation and require a REST mapping.
+                  \ In most cases, the dependency is on the group,resource tuple and
+                  the version of the actual struct is irrelevant. 5. We cannot easily
+                  change it.  Because this type is embedded in many locations, updates
+                  to this type will affect numerous schemas.  Don't make new APIs
+                  embed an underspecified API type they do not control. \n Instead
+                  of using this type, create a locally provided and used type that
+                  is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  ."
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -111,11 +108,22 @@ spec:
                 x-kubernetes-map-type: atomic
               displayName:
                 type: string
+              enableAutoImport:
+                default: false
+                type: boolean
               isManagedCluster:
                 type: boolean
               name:
                 type: string
+              ocpClusterId:
+                type: string
               openshiftVersion:
+                type: string
+              owner:
+                type: string
+              region:
+                type: string
+              rhocmClusterId:
                 type: string
               status:
                 type: string
@@ -173,29 +181,30 @@ spec:
                 format: date-time
                 type: string
               credential:
-                description: 'ObjectReference contains enough information to let you
+                description: "ObjectReference contains enough information to let you
                   inspect or modify the referred object. --- New uses of this type
                   are discouraged because of difficulty describing its usage when
                   embedded in APIs. 1. Ignored fields.  It includes many fields which
                   are not generally honored.  For instance, ResourceVersion and FieldPath
-                  are both very rarely valid in actual usage. 2. Invalid usage help.  It
-                  is impossible to add specific help for individual usage.  In most
-                  embedded usages, there are particular restrictions like, "must refer
-                  only to types A and B" or "UID not honored" or "name must be restricted".
-                  Those cannot be well described when embedded. 3. Inconsistent validation.  Because
-                  the usages are different, the validation rules are different by
-                  usage, which makes it hard for users to predict what will happen.
-                  4. The fields are both imprecise and overly precise.  Kind is not
-                  a precise mapping to a URL. This can produce ambiguity during interpretation
-                  and require a REST mapping.  In most cases, the dependency is on
-                  the group,resource tuple and the version of the actual struct is
-                  irrelevant. 5. We cannot easily change it.  Because this type is
-                  embedded in many locations, updates to this type will affect numerous
-                  schemas.  Don''t make new APIs embed an underspecified API type
-                  they do not control. Instead of using this type, create a locally
-                  provided and used type that is well-focused on your reference. For
-                  example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                  .'
+                  are both very rarely valid in actual usage. 2. Invalid usage help.
+                  \ It is impossible to add specific help for individual usage.  In
+                  most embedded usages, there are particular restrictions like, \"must
+                  refer only to types A and B\" or \"UID not honored\" or \"name must
+                  be restricted\". Those cannot be well described when embedded. 3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen. 4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity during interpretation and require a REST mapping.
+                  \ In most cases, the dependency is on the group,resource tuple and
+                  the version of the actual struct is irrelevant. 5. We cannot easily
+                  change it.  Because this type is embedded in many locations, updates
+                  to this type will affect numerous schemas.  Don't make new APIs
+                  embed an underspecified API type they do not control. \n Instead
+                  of using this type, create a locally provided and used type that
+                  is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  ."
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -237,7 +246,11 @@ spec:
                 type: boolean
               name:
                 type: string
+              ocpClusterId:
+                type: string
               openshiftVersion:
+                type: string
+              rhocmClusterId:
                 type: string
               status:
                 type: string

--- a/config/crd/bases/discovery.open-cluster-management.io_discoveredclusters.yaml
+++ b/config/crd/bases/discovery.open-cluster-management.io_discoveredclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: discoveredclusters.discovery.open-cluster-management.io
 spec:
@@ -42,39 +42,36 @@ spec:
                 type: string
               cloudProvider:
                 type: string
-              ocpClusterId:
-                type: string
-              rhocmClusterId:
-                type: string
               console:
                 type: string
               creationTimestamp:
                 format: date-time
                 type: string
               credential:
-                description: 'ObjectReference contains enough information to let you
+                description: "ObjectReference contains enough information to let you
                   inspect or modify the referred object. --- New uses of this type
                   are discouraged because of difficulty describing its usage when
                   embedded in APIs. 1. Ignored fields.  It includes many fields which
                   are not generally honored.  For instance, ResourceVersion and FieldPath
-                  are both very rarely valid in actual usage. 2. Invalid usage help.  It
-                  is impossible to add specific help for individual usage.  In most
-                  embedded usages, there are particular restrictions like, "must refer
-                  only to types A and B" or "UID not honored" or "name must be restricted".
-                  Those cannot be well described when embedded. 3. Inconsistent validation.  Because
-                  the usages are different, the validation rules are different by
-                  usage, which makes it hard for users to predict what will happen.
-                  4. The fields are both imprecise and overly precise.  Kind is not
-                  a precise mapping to a URL. This can produce ambiguity during interpretation
-                  and require a REST mapping.  In most cases, the dependency is on
-                  the group,resource tuple and the version of the actual struct is
-                  irrelevant. 5. We cannot easily change it.  Because this type is
-                  embedded in many locations, updates to this type will affect numerous
-                  schemas.  Don''t make new APIs embed an underspecified API type
-                  they do not control. Instead of using this type, create a locally
-                  provided and used type that is well-focused on your reference. For
-                  example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                  .'
+                  are both very rarely valid in actual usage. 2. Invalid usage help.
+                  \ It is impossible to add specific help for individual usage.  In
+                  most embedded usages, there are particular restrictions like, \"must
+                  refer only to types A and B\" or \"UID not honored\" or \"name must
+                  be restricted\". Those cannot be well described when embedded. 3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen. 4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity during interpretation and require a REST mapping.
+                  \ In most cases, the dependency is on the group,resource tuple and
+                  the version of the actual struct is irrelevant. 5. We cannot easily
+                  change it.  Because this type is embedded in many locations, updates
+                  to this type will affect numerous schemas.  Don't make new APIs
+                  embed an underspecified API type they do not control. \n Instead
+                  of using this type, create a locally provided and used type that
+                  is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  ."
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -112,11 +109,22 @@ spec:
                 x-kubernetes-map-type: atomic
               displayName:
                 type: string
+              enableAutoImport:
+                default: false
+                type: boolean
               isManagedCluster:
                 type: boolean
               name:
                 type: string
+              ocpClusterId:
+                type: string
               openshiftVersion:
+                type: string
+              owner:
+                type: string
+              region:
+                type: string
+              rhocmClusterId:
                 type: string
               status:
                 type: string
@@ -164,39 +172,36 @@ spec:
                 type: string
               cloudProvider:
                 type: string
-              ocpClusterId:
-                type: string
-              rhocmClusterId:
-                type: string
               console:
                 type: string
               creationTimestamp:
                 format: date-time
                 type: string
               credential:
-                description: 'ObjectReference contains enough information to let you
+                description: "ObjectReference contains enough information to let you
                   inspect or modify the referred object. --- New uses of this type
                   are discouraged because of difficulty describing its usage when
                   embedded in APIs. 1. Ignored fields.  It includes many fields which
                   are not generally honored.  For instance, ResourceVersion and FieldPath
-                  are both very rarely valid in actual usage. 2. Invalid usage help.  It
-                  is impossible to add specific help for individual usage.  In most
-                  embedded usages, there are particular restrictions like, "must refer
-                  only to types A and B" or "UID not honored" or "name must be restricted".
-                  Those cannot be well described when embedded. 3. Inconsistent validation.  Because
-                  the usages are different, the validation rules are different by
-                  usage, which makes it hard for users to predict what will happen.
-                  4. The fields are both imprecise and overly precise.  Kind is not
-                  a precise mapping to a URL. This can produce ambiguity during interpretation
-                  and require a REST mapping.  In most cases, the dependency is on
-                  the group,resource tuple and the version of the actual struct is
-                  irrelevant. 5. We cannot easily change it.  Because this type is
-                  embedded in many locations, updates to this type will affect numerous
-                  schemas.  Don''t make new APIs embed an underspecified API type
-                  they do not control. Instead of using this type, create a locally
-                  provided and used type that is well-focused on your reference. For
-                  example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                  .'
+                  are both very rarely valid in actual usage. 2. Invalid usage help.
+                  \ It is impossible to add specific help for individual usage.  In
+                  most embedded usages, there are particular restrictions like, \"must
+                  refer only to types A and B\" or \"UID not honored\" or \"name must
+                  be restricted\". Those cannot be well described when embedded. 3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen. 4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity during interpretation and require a REST mapping.
+                  \ In most cases, the dependency is on the group,resource tuple and
+                  the version of the actual struct is irrelevant. 5. We cannot easily
+                  change it.  Because this type is embedded in many locations, updates
+                  to this type will affect numerous schemas.  Don't make new APIs
+                  embed an underspecified API type they do not control. \n Instead
+                  of using this type, create a locally provided and used type that
+                  is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  ."
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -238,7 +243,11 @@ spec:
                 type: boolean
               name:
                 type: string
+              ocpClusterId:
+                type: string
               openshiftVersion:
+                type: string
+              rhocmClusterId:
                 type: string
               status:
                 type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -115,3 +115,12 @@ rules:
   - managedclusters/accept
   verbs:
   - update
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+  verbs:
+    - get
+    - list
+    - watch
+

--- a/controllers/discoveredcluster_import_controller.go
+++ b/controllers/discoveredcluster_import_controller.go
@@ -75,7 +75,7 @@ func (r *DiscoveredClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		If the discovered cluster has an Automatic import strategy, we need to ensure that the required resources
 		are available. Otherwise, we will ignore that cluster.
 	*/
-	if !dc.Spec.IsManagedCluster && dc.Annotations[discovery.ImportStrategyAnnotation] == "Automatic" {
+	if !dc.Spec.IsManagedCluster && dc.Spec.EnableAutoImport {
 		if res, err := r.EnsureNamespaceForDiscoveredCluster(ctx, *dc); err != nil {
 			logf.Error(err, "failed to ensure namespace for DiscoveredCluster", "Name", dc.Spec.DisplayName)
 			return res, err
@@ -97,10 +97,10 @@ func (r *DiscoveredClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
-	if res, err := r.EnsureFinalizerRemovedFromManagedCluster(ctx, *dc); err != nil {
-		logf.Error(err, "failed to ensure finalizer removed from ManagedCluster")
-		return res, err
-	}
+	// if res, err := r.EnsureFinalizerRemovedFromManagedCluster(ctx, *dc); err != nil {
+	// 	logf.Error(err, "failed to ensure finalizer removed from ManagedCluster")
+	// 	return res, err
+	// }
 
 	return ctrl.Result{RequeueAfter: reconciler.RefreshInterval}, nil
 }
@@ -182,9 +182,9 @@ func (r *DiscoveredClusterReconciler) CreateManagedCluster(nn types.NamespacedNa
 			Annotations: map[string]string{
 				discovery.CreatedViaAnnotation: "discovery",
 			},
-			Finalizers: []string{
-				discovery.ImportCleanUpFinalizer,
-			},
+			// Finalizers: []string{
+			// 	discovery.ImportCleanUpFinalizer,
+			// },
 		},
 		Spec: clusterapiv1.ManagedClusterSpec{
 			HubAcceptsClient: true,

--- a/controllers/discoveredcluster_import_controller.go
+++ b/controllers/discoveredcluster_import_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stolostron/discovery/util/reconciler"
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,6 +77,16 @@ func (r *DiscoveredClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		are available. Otherwise, we will ignore that cluster.
 	*/
 	if !dc.Spec.IsManagedCluster && dc.Spec.EnableAutoImport {
+		crdName := "klusterletaddonconfigs.agent.open-cluster-management.io"
+
+		if res, err := r.EnsureCRDExist(ctx, crdName); err != nil && apierrors.IsNotFound(err) {
+			return ctrl.Result{RequeueAfter: reconciler.ResyncPeriod}, nil
+
+		} else if err != nil {
+			logf.Error(err, "failed to ensure custom resource definition exist", "Name", crdName)
+			return res, err
+		}
+
 		if res, err := r.EnsureNamespaceForDiscoveredCluster(ctx, *dc); err != nil {
 			logf.Error(err, "failed to ensure namespace for DiscoveredCluster", "Name", dc.Spec.DisplayName)
 			return res, err
@@ -283,6 +294,25 @@ func (r *DiscoveredClusterReconciler) EnsureKlusterletAddonConfig(ctx context.Co
 
 	} else if err != nil {
 		logf.Error(err, "failed to get KlusterAddonConfig", "Name", nn.Name)
+		return ctrl.Result{RequeueAfter: reconciler.ResyncPeriod}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// EnsureCRDExist checks if a Custom Resource Definition (CRD) with the specified name exists in the cluster.
+// If the CRD exists, it returns indicating that the reconciliation should continue without requeueing.
+// If the CRD doesn't exist, it logs a message indicating that the CRD was not found and returns.
+// If an error occurs while getting the CRD (other than IsNotFound), it logs an error message and returns an error.
+func (r *DiscoveredClusterReconciler) EnsureCRDExist(ctx context.Context, crdName string) (ctrl.Result, error) {
+	crd := &apiextv1.CustomResourceDefinition{}
+
+	if err := r.Get(ctx, types.NamespacedName{Name: crdName}, crd); err != nil && apierrors.IsNotFound(err) {
+		logf.Info("CRD not found. Ignoring since object must be deleted", "Name", crdName)
+		return ctrl.Result{}, err
+
+	} else if err != nil {
+		logf.Error(err, "failed to get CRD", "Name", crdName)
 		return ctrl.Result{RequeueAfter: reconciler.ResyncPeriod}, err
 	}
 

--- a/controllers/discoveredcluster_import_controller_test.go
+++ b/controllers/discoveredcluster_import_controller_test.go
@@ -66,14 +66,14 @@ func Test_DiscoveredCluster_Reconciler_Reconcile(t *testing.T) {
 			},
 			dc: &discovery.DiscoveredCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "310ac28e-b69b-447b-a51f-08e967cff1ee",
-					Namespace:   "discovery",
-					Annotations: map[string]string{discovery.ImportStrategyAnnotation: "Automatic"},
+					Name:      "310ac28e-b69b-447b-a51f-08e967cff1ee",
+					Namespace: "discovery",
 				},
 				Spec: discovery.DiscoveredClusterSpec{
-					DisplayName:    "fake-cluster",
-					RHOCMClusterID: "349bcdc1dd6a44f3a1a136b2f98a69ca",
-					Type:           "ROSA",
+					DisplayName:      "fake-cluster",
+					EnableAutoImport: true,
+					RHOCMClusterID:   "349bcdc1dd6a44f3a1a136b2f98a69ca",
+					Type:             "ROSA",
 				},
 			},
 			req: ctrl.Request{

--- a/controllers/discoveredcluster_import_controller_test.go
+++ b/controllers/discoveredcluster_import_controller_test.go
@@ -21,6 +21,7 @@ import (
 	discovery "github.com/stolostron/discovery/api/v1"
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -37,6 +38,7 @@ func registerScheme() {
 	clusterapiv1.AddToScheme(scheme.Scheme)
 	discovery.AddToScheme(scheme.Scheme)
 	agentv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	apiextv1.AddToScheme(scheme.Scheme)
 }
 
 func Test_DiscoveredCluster_Reconciler_Reconcile(t *testing.T) {

--- a/controllers/managedcluster_controller.go
+++ b/controllers/managedcluster_controller.go
@@ -78,11 +78,10 @@ func (r *ManagedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			if dc.GetName() == req.Name || dc.Spec.DisplayName == req.Name {
 				modifiedDC := dc.DeepCopy()
 
-				if modifiedDC.GetAnnotations() == nil {
-					modifiedDC.SetAnnotations(make(map[string]string))
+				if modifiedDC.Spec.EnableAutoImport {
+					modifiedDC.Spec.EnableAutoImport = false
 				}
 
-				delete(modifiedDC.Annotations, discovery.ImportStrategyAnnotation)
 				if err := r.Patch(ctx, modifiedDC, client.MergeFrom(dc)); err != nil {
 					logf.Error(err, "failed to patch DiscoveredCluster", "Name", dc.GetName())
 					return ctrl.Result{RequeueAfter: reconciler.ResyncPeriod}, err
@@ -149,6 +148,7 @@ func (r *ManagedClusterReconciler) updateManagedLabels(ctx context.Context, mana
 				}
 				log.Info("Updated cluster, adding managed status", "discoveredcluster", dc.Name, "discoveredcluster namespace", dc.Namespace)
 			}
+
 		} else {
 			if updateRequired := unsetManagedStatus(&dc); updateRequired {
 				// Update with managed labels removed

--- a/controllers/managedcluster_controller_test.go
+++ b/controllers/managedcluster_controller_test.go
@@ -37,13 +37,11 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "c3po",
 			Namespace: TestManagedNamespace,
-			Annotations: map[string]string{
-				discovery.ImportStrategyAnnotation: "Automatic",
-			},
 		},
 		Spec: discovery.DiscoveredClusterSpec{
 			Name:              "c3po",
 			DisplayName:       "c3po",
+			EnableAutoImport:  true,
 			OpenshiftVersion:  "4.9.0",
 			CreationTimestamp: &mockManagedTime,
 			ActivityTimestamp: &mockManagedTime,
@@ -54,13 +52,11 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "c4po",
 			Namespace: TestManagedNamespace,
-			Annotations: map[string]string{
-				discovery.ImportStrategyAnnotation: "Automatic",
-			},
 		},
 		Spec: discovery.DiscoveredClusterSpec{
 			Name:              "c4po",
 			DisplayName:       "c4po",
+			EnableAutoImport:  true,
 			OpenshiftVersion:  "4.15.0",
 			CreationTimestamp: &mockManagedTime,
 			ActivityTimestamp: &mockManagedTime,
@@ -385,10 +381,6 @@ func Test_ManagedCluster_Reconciler_Reconcile(t *testing.T) {
 			if err := mcr.Get(context.TODO(), types.NamespacedName{
 				Name: mockCluster415.GetName(), Namespace: mockCluster415.GetNamespace()}, dc); err != nil {
 				t.Errorf("failed to get DiscoveredCluster: %v", err)
-			}
-
-			if dc.Annotations[discovery.ImportStrategyAnnotation] != "" {
-				t.Errorf("failed to remove import strategy annotation from DiscoveredCluster: %v", dc)
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	clusterapiv1 "open-cluster-management.io/api/cluster/v1"
 
@@ -65,6 +67,8 @@ func init() {
 	utilruntime.Must(discoveryv1.AddToScheme(scheme))
 
 	utilruntime.Must(agentv1.SchemeBuilder.AddToScheme(scheme))
+
+	utilruntime.Must(apiextv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -71,18 +71,20 @@ func formatCluster(sub subscription.Subscription) (discovery.DiscoveredCluster, 
 			Name: sub.ExternalClusterID,
 		},
 		Spec: discovery.DiscoveredClusterSpec{
-			Name:              sub.ExternalClusterID,
-			DisplayName:       computeDisplayName(sub),
-			Console:           sub.ConsoleURL,
-			OCPClusterID:      sub.ExternalClusterID,
-			RHOCMClusterID:    sub.ClusterID,
 			APIURL:            computeApiUrl(sub),
-			CreationTimestamp: sub.CreatedAt,
 			ActivityTimestamp: sub.LastTelemetryDate,
-			Type:              computeType(sub),
-			OpenshiftVersion:  sub.Metrics[0].OpenShiftVersion,
 			CloudProvider:     sub.CloudProviderID,
+			Console:           sub.ConsoleURL,
+			CreationTimestamp: sub.CreatedAt,
+			DisplayName:       computeDisplayName(sub),
+			Name:              sub.ExternalClusterID,
+			OCPClusterID:      sub.ExternalClusterID,
+			OpenshiftVersion:  sub.Metrics[0].OpenShiftVersion,
+			Owner:             sub.Creator.UserName,
+			Region:            sub.RegionID,
+			RHOCMClusterID:    sub.ClusterID,
 			Status:            sub.Status,
+			Type:              computeType(sub),
 		},
 	}
 	return discoveredCluster, true
@@ -91,10 +93,7 @@ func formatCluster(sub subscription.Subscription) (discovery.DiscoveredCluster, 
 // IsUnrecoverable returns true if the specified error is not temporary
 // and will continue to occur with the current state.
 func IsUnrecoverable(err error) bool {
-	if errors.Is(err, auth.ErrInvalidToken) {
-		return true
-	}
-	return false
+	return errors.Is(err, auth.ErrInvalidToken)
 }
 
 // computeDisplayName tries to provide a more user-friendly name if set

--- a/pkg/ocm/subscription/domain.go
+++ b/pkg/ocm/subscription/domain.go
@@ -9,9 +9,22 @@ import (
 
 // StandardKind ...
 type StandardKind struct {
-	Kind string `yaml:"kind,omitempty"`
-	ID   string `yaml:"id,omitempty"`
-	Href string `href:"kind,omitempty"`
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	ID   string `json:"id,omitempty" yaml:"id,omitempty"`
+	Href string `json:"href,omitempty" yaml:"href,omitempty"`
+	Type string `json:"type,omitempty" yaml:"type,omitempty"`
+}
+
+// Creator ...
+type Creator struct {
+	Email     string `json:"email,omitempty" yaml:"email,omitempty"`
+	FirstName string `json:"first_name,omitempty" yaml:"first_name,omitempty"`
+	Href      string `json:"href,omitempty" yaml:"href,omitempty"`
+	ID        string `json:"id,omitempty" yaml:"id,omitempty"`
+	Kind      string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	LastName  string `json:"last_name,omitempty" yaml:"last_name,omitempty"`
+	Name      string `json:"name,omitempty" yaml:"name,omitempty"`
+	UserName  string `json:"username,omitempty" yaml:"username,omitempty"`
 }
 
 // Metrics ...
@@ -21,27 +34,28 @@ type Metrics struct {
 
 // Subscription ...
 type Subscription struct {
-	ID                string       `json:"id"`
-	Kind              string       `json:"kind"`
-	Href              string       `json:"href"`
-	Plan              StandardKind `json:"plan,omitempty"`
-	ClusterID         string       `json:"cluster_id,omitempty"`
-	ConsoleURL        string       `json:"console_url,omitempty"`
-	ExternalClusterID string       `json:"external_cluster_id,omitempty"`
-	OrganizationID    string       `json:"organization_id,omitempty"`
-	LastTelemetryDate *metav1.Time `json:"last_telemetry_date,omitempty"`
-	CreatedAt         *metav1.Time `json:"created_at,omitempty"`
-	UpdatedAt         *metav1.Time `json:"updated_at,omitempty"`
-	Metrics           []Metrics    `json:"metrics,omitempty"`
-	CloudProviderID   string       `json:"cloud_provider_id,omitempty"`
-	SupportLevel      string       `json:"support_level,omitempty"`
-	DisplayName       string       `json:"display_name,omitempty"`
-	Creator           StandardKind `json:"creator"`
-	Managed           bool         `json:"managed,omitempty"`
-	Status            string       `json:"status"`
-	Provenance        string       `json:"provenance,omitempty"`
-	LastReconcileDate *metav1.Time `json:"last_reconcile_date,omitempty"`
-	LastReleasedAt    string       `json:"last_released_at,omitempty"`
+	ClusterID         string       `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty"`
+	CloudProviderID   string       `json:"cloud_provider_id,omitempty" yaml:"cloud_provider_id,omitempty"`
+	ConsoleURL        string       `json:"console_url,omitempty" yaml:"console_url,omitempty"`
+	CreatedAt         *metav1.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	Creator           Creator      `json:"creator" yaml:"creator"`
+	DisplayName       string       `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	ExternalClusterID string       `json:"external_cluster_id,omitempty" yaml:"external_cluster_id,omitempty"`
+	Href              string       `json:"href" yaml:"href"`
+	ID                string       `json:"id" yaml:"id"`
+	Kind              string       `json:"kind" yaml:"kind"`
+	LastReconcileDate *metav1.Time `json:"last_reconcile_date,omitempty" yaml:"last_reconcile_date,omitempty"`
+	LastReleasedAt    string       `json:"last_released_at,omitempty" yaml:"last_released_at,omitempty"`
+	LastTelemetryDate *metav1.Time `json:"last_telemetry_date,omitempty" yaml:"last_telemetry_date,omitempty"`
+	Managed           bool         `json:"managed,omitempty" yaml:"managed,omitempty"`
+	Metrics           []Metrics    `json:"metrics,omitempty" yaml:"metrics,omitempty"`
+	OrganizationID    string       `json:"organization_id,omitempty" yaml:"organization_id,omitempty"`
+	Plan              StandardKind `json:"plan,omitempty" yaml:"plan,omitempty"`
+	Provenance        string       `json:"provenance,omitempty" yaml:"provenance,omitempty"`
+	RegionID          string       `json:"region_id,omitempty" yaml:"region_id,omitempty"`
+	Status            string       `json:"status" yaml:"status"`
+	SupportLevel      string       `json:"support_level,omitempty" yaml:"support_level,omitempty"`
+	UpdatedAt         *metav1.Time `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 }
 
 // SubscriptionResponse ...

--- a/pkg/ocm/subscription/service_test.go
+++ b/pkg/ocm/subscription/service_test.go
@@ -52,7 +52,7 @@ func TestGetSubscriptionsNoError(t *testing.T) {
 					Kind:    "Subscription",
 					ID:      "123abc",
 					Href:    "/api/accounts_mgmt/v1/subscriptions/123abc",
-					Creator: StandardKind{},
+					Creator: Creator{},
 					Status:  "Active",
 				},
 			},

--- a/test/resources/klusterletaddonconfig-crd.yml
+++ b/test/resources/klusterletaddonconfig-crd.yml
@@ -1,0 +1,215 @@
+# Copyright (c) 2020 Red Hat, Inc.
+
+# Copyright Contributors to the Open Cluster Management project
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: klusterletaddonconfigs.agent.open-cluster-management.io
+spec:
+  group: agent.open-cluster-management.io
+  names:
+    kind: KlusterletAddonConfig
+    listKind: KlusterletAddonConfigList
+    plural: klusterletaddonconfigs
+    singular: klusterletaddonconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KlusterletAddonConfig is the Schema for the klusterletaddonconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KlusterletAddonConfigSpec defines the desired state of KlusterletAddonConfig
+            properties:
+              applicationManager:
+                description: ApplicationManagerConfig defines the configurations of ApplicationManager addon agent.
+                properties:
+                  enabled:
+                    description: Enabled is the flag to enable/disable the addon. default is false.
+                    type: boolean
+                  proxyPolicy:
+                    description: ProxyPolicy defines the policy to set proxy for each addon agent. default is Disabled. Disabled means that the addon agent pods do not configure the proxy env variables. OCPGlobalProxy means that the addon agent pods use the cluster-wide proxy config of OCP cluster provisioned by ACM. CustomProxy means that the addon agent pods use the ProxyConfig specified in KlusterletAddonConfig.
+                    enum:
+                    - Disabled
+                    - OCPGlobalProxy
+                    - CustomProxy
+                    type: string
+                type: object
+              certPolicyController:
+                description: CertPolicyControllerConfig defines the configurations of CertPolicyController addon agent.
+                properties:
+                  enabled:
+                    description: Enabled is the flag to enable/disable the addon. default is false.
+                    type: boolean
+                  proxyPolicy:
+                    description: ProxyPolicy defines the policy to set proxy for each addon agent. default is Disabled. Disabled means that the addon agent pods do not configure the proxy env variables. OCPGlobalProxy means that the addon agent pods use the cluster-wide proxy config of OCP cluster provisioned by ACM. CustomProxy means that the addon agent pods use the ProxyConfig specified in KlusterletAddonConfig.
+                    enum:
+                    - Disabled
+                    - OCPGlobalProxy
+                    - CustomProxy
+                    type: string
+                type: object
+              clusterLabels:
+                additionalProperties:
+                  type: string
+                description: DEPRECATED in release 2.4 and will be removed in the future since not used anymore.
+                type: object
+              clusterName:
+                description: DEPRECATED in release 2.4 and will be removed in the future since not used anymore.
+                minLength: 1
+                type: string
+              clusterNamespace:
+                description: DEPRECATED in release 2.4 and will be removed in the future since not used anymore.
+                minLength: 1
+                type: string
+              iamPolicyController:
+                description: IAMPolicyControllerConfig defines the configurations of IamPolicyController addon agent.
+                properties:
+                  enabled:
+                    description: Enabled is the flag to enable/disable the addon. default is false.
+                    type: boolean
+                  proxyPolicy:
+                    description: ProxyPolicy defines the policy to set proxy for each addon agent. default is Disabled. Disabled means that the addon agent pods do not configure the proxy env variables. OCPGlobalProxy means that the addon agent pods use the cluster-wide proxy config of OCP cluster provisioned by ACM. CustomProxy means that the addon agent pods use the ProxyConfig specified in KlusterletAddonConfig.
+                    enum:
+                    - Disabled
+                    - OCPGlobalProxy
+                    - CustomProxy
+                    type: string
+                type: object
+              policyController:
+                description: PolicyController defines the configurations of PolicyController addon agent.
+                properties:
+                  enabled:
+                    description: Enabled is the flag to enable/disable the addon. default is false.
+                    type: boolean
+                  proxyPolicy:
+                    description: ProxyPolicy defines the policy to set proxy for each addon agent. default is Disabled. Disabled means that the addon agent pods do not configure the proxy env variables. OCPGlobalProxy means that the addon agent pods use the cluster-wide proxy config of OCP cluster provisioned by ACM. CustomProxy means that the addon agent pods use the ProxyConfig specified in KlusterletAddonConfig.
+                    enum:
+                    - Disabled
+                    - OCPGlobalProxy
+                    - CustomProxy
+                    type: string
+                type: object
+              proxyConfig:
+                description: ProxyConfig defines the cluster-wide proxy configuration of the OCP managed cluster.
+                properties:
+                  httpProxy:
+                    description: HTTPProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
+                    type: string
+                  httpsProxy:
+                    description: HTTPSProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.
+                    type: string
+                  noProxy:
+                    description: NoProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used. Empty means unset and will not result in an env var. The API Server of Hub cluster should be added here. And If you scale up workers that are not included in the network defined by the networking.machineNetwork[].cidr field from the installation configuration, you must add them to this list to prevent connection issues.
+                    type: string
+                type: object
+              searchCollector:
+                description: SearchCollectorConfig defines the configurations of SearchCollector addon agent.
+                properties:
+                  enabled:
+                    description: Enabled is the flag to enable/disable the addon. default is false.
+                    type: boolean
+                  proxyPolicy:
+                    description: ProxyPolicy defines the policy to set proxy for each addon agent. default is Disabled. Disabled means that the addon agent pods do not configure the proxy env variables. OCPGlobalProxy means that the addon agent pods use the cluster-wide proxy config of OCP cluster provisioned by ACM. CustomProxy means that the addon agent pods use the ProxyConfig specified in KlusterletAddonConfig.
+                    enum:
+                    - Disabled
+                    - OCPGlobalProxy
+                    - CustomProxy
+                    type: string
+                type: object
+              version:
+                description: DEPRECATED in release 2.4 and will be removed in the future since not used anymore.
+                type: string
+            required:
+            - applicationManager
+            - certPolicyController
+            - iamPolicyController
+            - policyController
+            - searchCollector
+            type: object
+          status:
+            description: KlusterletAddonConfigStatus defines the observed state of KlusterletAddonConfig
+            properties:
+              conditions:
+                description: Conditions contains condition information for the klusterletAddonConfig
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ocpGlobalProxy:
+                description: OCPGlobalProxy is the cluster-wide proxy config of the OCP cluster provisioned by ACM
+                properties:
+                  httpProxy:
+                    description: HTTPProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
+                    type: string
+                  httpsProxy:
+                    description: HTTPSProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.
+                    type: string
+                  noProxy:
+                    description: NoProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used. Empty means unset and will not result in an env var. The API Server of Hub cluster should be added here. And If you scale up workers that are not included in the network defined by the networking.machineNetwork[].cidr field from the installation configuration, you must add them to this list to prevent connection issues.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
# Description

Updating the import logic to use DiscoveredCluster `spec.enableAutoImport`, rather than setting an annotation.

## Related Issue

https://issues.redhat.com/browse/ACM-10305

## Changes Made

Changed import logic to use `spec.enableAutoImport` vs `discovery.open-cluster-management.io/import-strategy` annotation.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
