### PR TITLE
[ACM-11047] Updated enableAutoImport field to importAsManagedCluster

### DIFF
--- a/api/v1/discoveredcluster_types.go
+++ b/api/v1/discoveredcluster_types.go
@@ -44,23 +44,23 @@ const (
 
 // DiscoveredClusterSpec defines the desired state of DiscoveredCluster
 type DiscoveredClusterSpec struct {
-	ActivityTimestamp *metav1.Time           `json:"activityTimestamp,omitempty" yaml:"activityTimestamp,omitempty"`
-	APIURL            string                 `json:"apiUrl" yaml:"apiUrl"`
-	CloudProvider     string                 `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`
-	Console           string                 `json:"console,omitempty" yaml:"console,omitempty"`
-	CreationTimestamp *metav1.Time           `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
-	Credential        corev1.ObjectReference `json:"credential,omitempty" yaml:"credential,omitempty"`
-	DisplayName       string                 `json:"displayName" yaml:"displayName"`
-	EnableAutoImport  bool                   `json:"enableAutoImport,omitempty" yaml:"enableAutoImport,omitempty"`
-	IsManagedCluster  bool                   `json:"isManagedCluster" yaml:"isManagedCluster"`
-	Name              string                 `json:"name" yaml:"name"`
-	OCPClusterID      string                 `json:"ocpClusterId,omitempty" yaml:"ocpClusterId,omitempty"`
-	OpenshiftVersion  string                 `json:"openshiftVersion,omitempty" yaml:"openshiftVersion,omitempty"`
-	Owner             string                 `json:"owner,omitempty" yaml:"owner,omitempty"`
-	RHOCMClusterID    string                 `json:"rhocmClusterId,omitempty" yaml:"rhocmClusterId,omitempty"`
-	Region            string                 `json:"region,omitempty" yaml:"region,omitempty"`
-	Status            string                 `json:"status,omitempty" yaml:"status,omitempty"`
-	Type              string                 `json:"type" yaml:"type"`
+	ActivityTimestamp      *metav1.Time           `json:"activityTimestamp,omitempty" yaml:"activityTimestamp,omitempty"`
+	APIURL                 string                 `json:"apiUrl" yaml:"apiUrl"`
+	CloudProvider          string                 `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`
+	Console                string                 `json:"console,omitempty" yaml:"console,omitempty"`
+	CreationTimestamp      *metav1.Time           `json:"creationTimestamp,omitempty" yaml:"creationTimestamp,omitempty"`
+	Credential             corev1.ObjectReference `json:"credential,omitempty" yaml:"credential,omitempty"`
+	DisplayName            string                 `json:"displayName" yaml:"displayName"`
+	ImportAsManagedCluster bool                   `json:"importAsManagedCluster,omitempty" yaml:"importAsManagedCluster,omitempty"`
+	IsManagedCluster       bool                   `json:"isManagedCluster" yaml:"isManagedCluster"`
+	Name                   string                 `json:"name" yaml:"name"`
+	OCPClusterID           string                 `json:"ocpClusterId,omitempty" yaml:"ocpClusterId,omitempty"`
+	OpenshiftVersion       string                 `json:"openshiftVersion,omitempty" yaml:"openshiftVersion,omitempty"`
+	Owner                  string                 `json:"owner,omitempty" yaml:"owner,omitempty"`
+	RHOCMClusterID         string                 `json:"rhocmClusterId,omitempty" yaml:"rhocmClusterId,omitempty"`
+	Region                 string                 `json:"region,omitempty" yaml:"region,omitempty"`
+	Status                 string                 `json:"status,omitempty" yaml:"status,omitempty"`
+	Type                   string                 `json:"type" yaml:"type"`
 }
 
 // DiscoveredClusterStatus defines the observed state of DiscoveredCluster
@@ -104,7 +104,7 @@ func (a DiscoveredCluster) Equal(b DiscoveredCluster) bool {
 		a.Spec.CreationTimestamp.Truncate(time.Second) != b.Spec.CreationTimestamp.Truncate(time.Second) ||
 		a.Spec.Credential != b.Spec.Credential ||
 		a.Spec.DisplayName != b.Spec.DisplayName ||
-		a.Spec.EnableAutoImport != b.Spec.EnableAutoImport ||
+		a.Spec.ImportAsManagedCluster != b.Spec.ImportAsManagedCluster ||
 		a.Spec.IsManagedCluster != b.Spec.IsManagedCluster ||
 		a.Spec.Name != b.Spec.Name ||
 		a.Spec.OpenshiftVersion != b.Spec.OpenshiftVersion ||

--- a/api/v1/discovery_webhook.go
+++ b/api/v1/discovery_webhook.go
@@ -110,9 +110,9 @@ func (r *DiscoveredCluster) ValidateCreate() (admission.Warnings, error) {
 	discoveredclusterLog.Info("validate create", "Name", r.Name)
 
 	// Validate resource
-	if r.Spec.Type != "ROSA" && r.Spec.EnableAutoImport {
+	if r.Spec.Type != "ROSA" && r.Spec.ImportAsManagedCluster {
 		return nil, fmt.Errorf(
-			"cannot create DiscoveredCluster '%s': enableAutoImport is not allowed for clusters of type '%s'. "+
+			"cannot create DiscoveredCluster '%s': importAsManagedCluster is not allowed for clusters of type '%s'. "+
 				"Only ROSA type clusters support auto import",
 			r.Spec.Type, r.Name,
 		)
@@ -130,9 +130,9 @@ func (r *DiscoveredCluster) ValidateUpdate(old runtime.Object) (admission.Warnin
 	}
 
 	oldDiscoveredCluster := old.(*DiscoveredCluster)
-	if oldDiscoveredCluster.Spec.Type != "ROSA" && r.Spec.EnableAutoImport {
+	if oldDiscoveredCluster.Spec.Type != "ROSA" && r.Spec.ImportAsManagedCluster {
 		return nil, fmt.Errorf(
-			"cannot update DiscoveredCluster '%s': enableAutoImport is not allowed for clusters of type '%s'."+
+			"cannot update DiscoveredCluster '%s': importAsManagedCluster is not allowed for clusters of type '%s'."+
 				"Only ROSA type clusters support auto import",
 			r.Spec.Type, r.Name,
 		)

--- a/bundle/manifests/discovery.open-cluster-management.io_discoveredclusters.yaml
+++ b/bundle/manifests/discovery.open-cluster-management.io_discoveredclusters.yaml
@@ -108,7 +108,7 @@ spec:
                 x-kubernetes-map-type: atomic
               displayName:
                 type: string
-              enableAutoImport:
+              importAsManagedCluster:
                 default: false
                 type: boolean
               isManagedCluster:

--- a/config/crd/bases/discovery.open-cluster-management.io_discoveredclusters.yaml
+++ b/config/crd/bases/discovery.open-cluster-management.io_discoveredclusters.yaml
@@ -109,7 +109,7 @@ spec:
                 x-kubernetes-map-type: atomic
               displayName:
                 type: string
-              enableAutoImport:
+              importAsManagedCluster:
                 default: false
                 type: boolean
               isManagedCluster:

--- a/controllers/discoveredcluster_controller.go
+++ b/controllers/discoveredcluster_controller.go
@@ -93,7 +93,7 @@ func (r *DiscoveredClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		If the discovered cluster has an Automatic import strategy, we need to ensure that the required resources
 		are available. Otherwise, we will ignore that cluster.
 	*/
-	if !dc.Spec.IsManagedCluster && dc.Spec.EnableAutoImport {
+	if !dc.Spec.IsManagedCluster && dc.Spec.ImportAsManagedCluster {
 		crdName := "klusterletaddonconfigs.agent.open-cluster-management.io"
 
 		if res, err := r.EnsureCRDExist(ctx, crdName); err != nil && apierrors.IsNotFound(err) {

--- a/controllers/discoveredcluster_controller_test.go
+++ b/controllers/discoveredcluster_controller_test.go
@@ -75,10 +75,10 @@ func Test_DiscoveredCluster_Reconciler_Reconcile(t *testing.T) {
 					Namespace: "discovery",
 				},
 				Spec: discovery.DiscoveredClusterSpec{
-					DisplayName:      "fake-cluster",
-					EnableAutoImport: true,
-					RHOCMClusterID:   "349bcdc1dd6a44f3a1a136b2f98a69ca",
-					Type:             "ROSA",
+					DisplayName:            "fake-cluster",
+					ImportAsManagedCluster: true,
+					RHOCMClusterID:         "349bcdc1dd6a44f3a1a136b2f98a69ca",
+					Type:                   "ROSA",
 				},
 			},
 			req: ctrl.Request{

--- a/controllers/managedcluster_controller.go
+++ b/controllers/managedcluster_controller.go
@@ -83,8 +83,8 @@ func (r *ManagedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			if dc.GetName() == req.Name || dc.Spec.DisplayName == req.Name {
 				modifiedDC := dc.DeepCopy()
 
-				if modifiedDC.Spec.EnableAutoImport {
-					modifiedDC.Spec.EnableAutoImport = false
+				if modifiedDC.Spec.ImportAsManagedCluster {
+					modifiedDC.Spec.ImportAsManagedCluster = false
 				}
 
 				if err := r.Patch(ctx, modifiedDC, client.MergeFrom(dc)); err != nil {

--- a/controllers/managedcluster_controller_test.go
+++ b/controllers/managedcluster_controller_test.go
@@ -39,12 +39,12 @@ var (
 			Namespace: TestManagedNamespace,
 		},
 		Spec: discovery.DiscoveredClusterSpec{
-			Name:              "c3po",
-			DisplayName:       "c3po",
-			EnableAutoImport:  true,
-			OpenshiftVersion:  "4.9.0",
-			CreationTimestamp: &mockManagedTime,
-			ActivityTimestamp: &mockManagedTime,
+			Name:                   "c3po",
+			DisplayName:            "c3po",
+			ImportAsManagedCluster: true,
+			OpenshiftVersion:       "4.9.0",
+			CreationTimestamp:      &mockManagedTime,
+			ActivityTimestamp:      &mockManagedTime,
 		},
 	}
 
@@ -54,12 +54,12 @@ var (
 			Namespace: TestManagedNamespace,
 		},
 		Spec: discovery.DiscoveredClusterSpec{
-			Name:              "c4po",
-			DisplayName:       "c4po",
-			EnableAutoImport:  true,
-			OpenshiftVersion:  "4.15.0",
-			CreationTimestamp: &mockManagedTime,
-			ActivityTimestamp: &mockManagedTime,
+			Name:                   "c4po",
+			DisplayName:            "c4po",
+			ImportAsManagedCluster: true,
+			OpenshiftVersion:       "4.15.0",
+			CreationTimestamp:      &mockManagedTime,
+			ActivityTimestamp:      &mockManagedTime,
 		},
 	}
 )


### PR DESCRIPTION
# Description

Updating the `DiscoveredCluster` spec `enableAutoImport` field to `importAsManagedCluster`. We are modifying the field to a more efficient naming convention.

## Related Issue

https://issues.redhat.com/browse/ACM-11047

## Changes Made

Changing `enableAutoImport` field name to `importAsManagedCluster`.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
