### PR TITLE
[ACM-11146] Updated auto-import controller to ignore missing KlusterletAddOnConfig in standalone MCE

### DIFF
--- a/controllers/discoveredcluster_controller_test.go
+++ b/controllers/discoveredcluster_controller_test.go
@@ -125,7 +125,6 @@ func Test_DiscoveredCluster_Reconciler_Reconcile(t *testing.T) {
 				r.Delete(context.TODO(), kac)
 				r.Delete(context.TODO(), s)
 				r.Delete(context.TODO(), mc)
-				r.EnsureFinalizerRemovedFromManagedCluster(context.TODO(), *tt.dc)
 				r.Delete(context.TODO(), ns)
 
 				r.Delete(context.TODO(), tt.dc)
@@ -491,10 +490,6 @@ func Test_Reconciler_EnsureManagedCluster(t *testing.T) {
 
 				if err := r.Delete(context.TODO(), ns); err != nil {
 					t.Errorf("failed to delete Namespace: %v", err)
-				}
-
-				if _, err := r.EnsureFinalizerRemovedFromManagedCluster(context.TODO(), *tt.dc); err != nil {
-					t.Errorf("failed to ensure finalizer removed from ManagedCluster: %v", err)
 				}
 
 				if err := r.Get(context.TODO(), types.NamespacedName{Name: tt.dc.Spec.DisplayName}, mc); err == nil {

--- a/controllers/managedcluster_controller.go
+++ b/controllers/managedcluster_controller.go
@@ -82,10 +82,7 @@ func (r *ManagedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 			if dc.GetName() == req.Name || dc.Spec.DisplayName == req.Name {
 				modifiedDC := dc.DeepCopy()
-
-				if modifiedDC.Spec.ImportAsManagedCluster {
-					modifiedDC.Spec.ImportAsManagedCluster = false
-				}
+				modifiedDC.Spec.ImportAsManagedCluster = false
 
 				if err := r.Patch(ctx, modifiedDC, client.MergeFrom(dc)); err != nil {
 					logf.Error(err, "failed to patch DiscoveredCluster", "Name", dc.GetName())


### PR DESCRIPTION
# Description

When a user deploy MCE as a standalone instance, we the `KlusterletAddOnConfig` CRD is not deployed on the cluster. MCH is responsible for deploying that resource; therefore, if the CRD does not exist, we should ignore it and allow the auto import of the `DiscoveredCluster` to continue as intended.

## Related Issue

https://issues.redhat.com/browse/ACM-11146

## Changes Made

Updated controller to ignore if `KlusterletAddOnConfig` CRD is not present on the cluster.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
