### PR TITLE
[ACM-10652] Added previously auto imported annotation to detached discoveredcluster

### DIFF
--- a/controllers/discoveredcluster_controller.go
+++ b/controllers/discoveredcluster_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	discovery "github.com/stolostron/discovery/api/v1"
@@ -93,36 +94,42 @@ func (r *DiscoveredClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		If the discovered cluster has an Automatic import strategy, we need to ensure that the required resources
 		are available. Otherwise, we will ignore that cluster.
 	*/
-	if !dc.Spec.IsManagedCluster && dc.Spec.ImportAsManagedCluster && !utils.IsAnnotationTrue(dc,
-		utils.AnnotationPreviouslyAutoImported) {
-		if res, err := r.EnsureNamespaceForDiscoveredCluster(ctx, *dc); err != nil {
-			logf.Error(err, "failed to ensure namespace for DiscoveredCluster", "Name", dc.Spec.DisplayName)
-			return res, err
-		}
-
-		if res, err := r.EnsureManagedCluster(ctx, *dc); err != nil {
-			logf.Error(err, "failed to ensure ManagedCluster created", "Name", dc.Spec.DisplayName)
-			return res, err
-		}
-
-		// Ensure that the KlusterletAddOnConfig CRD exists. In standalone MCE mode, the CRD is not deployed.
-		crdName := "klusterletaddonconfigs.agent.open-cluster-management.io"
-
-		if res, err := r.EnsureCRDExist(ctx, crdName); err != nil {
-			if !apierrors.IsNotFound(err) {
-				logf.Error(err, "failed to ensure custom resource definition exist", "Name", crdName)
+	if !dc.Spec.IsManagedCluster && dc.Spec.ImportAsManagedCluster {
+		if !utils.IsAnnotationTrue(dc, utils.AnnotationPreviouslyAutoImported) {
+			if res, err := r.EnsureNamespaceForDiscoveredCluster(ctx, *dc); err != nil {
+				logf.Error(err, "failed to ensure namespace for DiscoveredCluster", "Name", dc.Spec.DisplayName)
 				return res, err
 			}
+
+			if res, err := r.EnsureManagedCluster(ctx, *dc); err != nil {
+				logf.Error(err, "failed to ensure ManagedCluster created", "Name", dc.Spec.DisplayName)
+				return res, err
+			}
+
+			// Ensure that the KlusterletAddOnConfig CRD exists. In standalone MCE mode, the CRD is not deployed.
+			crdName := "klusterletaddonconfigs.agent.open-cluster-management.io"
+
+			if res, err := r.EnsureCRDExist(ctx, crdName); err != nil {
+				if !apierrors.IsNotFound(err) {
+					logf.Error(err, "failed to ensure custom resource definition exist", "Name", crdName)
+					return res, err
+				}
+			} else {
+				if res, err := r.EnsureKlusterletAddonConfig(ctx, *dc); err != nil {
+					logf.Error(err, "failed to ensure KlusterletAddonConfig created", "Name", dc.Spec.DisplayName)
+					return res, err
+				}
+			}
+
+			if res, err := r.EnsureAutoImportSecret(ctx, *dc, *config); err != nil {
+				logf.Error(err, "failed to ensure auto import Secret created", "Name", dc.Spec.DisplayName)
+				return res, err
+			}
+
 		} else {
-			if res, err := r.EnsureKlusterletAddonConfig(ctx, *dc); err != nil {
-				logf.Error(err, "failed to ensure KlusterletAddonConfig created", "Name", dc.Spec.DisplayName)
-				return res, err
-			}
-		}
-
-		if res, err := r.EnsureAutoImportSecret(ctx, *dc, *config); err != nil {
-			logf.Error(err, "failed to ensure auto import Secret created", "Name", dc.Spec.DisplayName)
-			return res, err
+			logf.Info(
+				fmt.Sprintf("Skipped automatic import for DiscoveredCluster due to existing '%v' annotation",
+					utils.AnnotationPreviouslyAutoImported), "Name", dc.Spec.DisplayName)
 		}
 	}
 

--- a/controllers/discoveredcluster_controller.go
+++ b/controllers/discoveredcluster_controller.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	discovery "github.com/stolostron/discovery/api/v1"
+	utils "github.com/stolostron/discovery/util"
 	recon "github.com/stolostron/discovery/util/reconciler"
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -92,7 +93,8 @@ func (r *DiscoveredClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		If the discovered cluster has an Automatic import strategy, we need to ensure that the required resources
 		are available. Otherwise, we will ignore that cluster.
 	*/
-	if !dc.Spec.IsManagedCluster && dc.Spec.ImportAsManagedCluster {
+	if !dc.Spec.IsManagedCluster && dc.Spec.ImportAsManagedCluster && !utils.IsAnnotationTrue(dc,
+		utils.AnnotationPreviouslyAutoImported) {
 		if res, err := r.EnsureNamespaceForDiscoveredCluster(ctx, *dc); err != nil {
 			logf.Error(err, "failed to ensure namespace for DiscoveredCluster", "Name", dc.Spec.DisplayName)
 			return res, err

--- a/util/annotations.go
+++ b/util/annotations.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"strings"
+
+	discovery "github.com/stolostron/discovery/api/v1"
+)
+
+var (
+	/*
+		AnnotationPreviouslyAutoImported is an annotation used to indicate that a discovered cluster was previously
+		imported automatically.
+	*/
+	AnnotationPreviouslyAutoImported = "discovery.open-cluster-management.io/previously-auto-imported"
+)
+
+/*
+IsAnnotationTrue checks if a specific annotation key in the given instance is set to "true".
+*/
+func IsAnnotationTrue(instance *discovery.DiscoveredCluster, annotationKey string) bool {
+	a := instance.GetAnnotations()
+	if a == nil {
+		return false
+	}
+
+	value := strings.EqualFold(a[annotationKey], "true")
+	return value
+}

--- a/util/annotations_test.go
+++ b/util/annotations_test.go
@@ -2,3 +2,53 @@
 // Copyright Contributors to the Open Cluster Management project
 
 package utils
+
+import (
+	"testing"
+
+	discovery "github.com/stolostron/discovery/api/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_IsAnnotationTrue(t *testing.T) {
+	tests := []struct {
+		name string
+		dc   *discovery.DiscoveredCluster
+		want bool
+	}{
+		{
+			name: "should return annotation being true",
+			dc: &discovery.DiscoveredCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					Annotations: map[string]string{
+						AnnotationPreviouslyAutoImported: "true",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "should return annotation being false",
+			dc: &discovery.DiscoveredCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					Annotations: map[string]string{
+						AnnotationPreviouslyAutoImported: "false",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAnnotationTrue(tt.dc, AnnotationPreviouslyAutoImported); got != tt.want {
+				t.Errorf("IsAnnotationTrue(tt.dc, AnnotationPreviouslyAutoImported) = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/util/annotations_test.go
+++ b/util/annotations_test.go
@@ -1,0 +1,4 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package utils


### PR DESCRIPTION
# Description

When a `DiscoveredCluster` is automatically imported, we need to ensure that if the associated `ManagedCluster` is detached for any reason, we should not re-auto import the `DiscoveredCluster` back into the hub. To address this scenario, we are adding an annotation when the `ManagedCluster` is detached to ensure that the cluster is not imported again by default. 

## Related Issue

https://issues.redhat.com/browse/ACM-10652

## Changes Made

Added annotation to prevent re-auto import.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [x] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [x] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
