### PR TITLE
[ACM-10996] Fixed credential config for auto-import secret

### DIFF
--- a/controllers/discoveredcluster_controller_test.go
+++ b/controllers/discoveredcluster_controller_test.go
@@ -75,6 +75,10 @@ func Test_DiscoveredCluster_Reconciler_Reconcile(t *testing.T) {
 					Namespace: "discovery",
 				},
 				Spec: discovery.DiscoveredClusterSpec{
+					Credential: corev1.ObjectReference{
+						Name:      "fake-admin",
+						Namespace: "discovery",
+					},
 					DisplayName:            "fake-cluster",
 					ImportAsManagedCluster: true,
 					RHOCMClusterID:         "349bcdc1dd6a44f3a1a136b2f98a69ca",
@@ -113,7 +117,8 @@ func Test_DiscoveredCluster_Reconciler_Reconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			DiscoveryConfig = types.NamespacedName{
-				Name: tt.config.Name, Namespace: tt.config.Namespace,
+				Name:      tt.config.Name,
+				Namespace: tt.config.Namespace,
 			}
 
 			ns := &corev1.Namespace{}
@@ -352,7 +357,11 @@ func Test_Reconciler_EnsureAutoImportSecret(t *testing.T) {
 				},
 				Spec: discovery.DiscoveredClusterSpec{
 					DisplayName: "foo",
-					Type:        "ROSA",
+					Credential: corev1.ObjectReference{
+						Name:      "admin",
+						Namespace: "discovery",
+					},
+					Type: "ROSA",
 				},
 			},
 			want: true,
@@ -389,7 +398,7 @@ func Test_Reconciler_EnsureAutoImportSecret(t *testing.T) {
 				t.Errorf("failed to create Secret: %v", err)
 			}
 
-			if _, err := r.EnsureAutoImportSecret(context.TODO(), *tt.dc, *tt.config); err != nil {
+			if _, err := r.EnsureAutoImportSecret(context.TODO(), *tt.dc); err != nil {
 				t.Errorf("failed to ensure auto import Secret created: %v", err)
 			}
 

--- a/controllers/discoveredcluster_controller_test.go
+++ b/controllers/discoveredcluster_controller_test.go
@@ -116,11 +116,6 @@ func Test_DiscoveredCluster_Reconciler_Reconcile(t *testing.T) {
 	registerScheme()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			DiscoveryConfig = types.NamespacedName{
-				Name:      tt.config.Name,
-				Namespace: tt.config.Namespace,
-			}
-
 			ns := &corev1.Namespace{}
 			mc := &clusterapiv1.ManagedCluster{}
 			kac := &agentv1.KlusterletAddonConfig{}

--- a/controllers/discoveryconfig_controller.go
+++ b/controllers/discoveryconfig_controller.go
@@ -49,7 +49,6 @@ var (
 	// baseURLAnnotation is the annotation set in a DiscoveryConfig that overrides the URL base used to find clusters
 	baseURLAnnotation     = "ocmBaseURL"
 	baseAuthURLAnnotation = "authBaseURL"
-	DiscoveryConfig       types.NamespacedName
 )
 
 var ErrBadFormat = errors.New("bad format")
@@ -95,10 +94,6 @@ func (r *DiscoveryConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 		// If there's an error other than "Not Found", return with the error.
 		return ctrl.Result{}, fmt.Errorf("failed to get DiscoveryConfig %s: %w", req.Name, err)
-	}
-	DiscoveryConfig = types.NamespacedName{
-		Name:      config.GetName(),
-		Namespace: config.GetNamespace(),
 	}
 
 	if err = r.updateDiscoveredClusters(ctx, config); err != nil {
@@ -376,8 +371,4 @@ func getAuthURLOverride(config *discovery.DiscoveryConfig) string {
 		return annotations[baseAuthURLAnnotation]
 	}
 	return ""
-}
-
-func GetDiscoveryConfig() types.NamespacedName {
-	return DiscoveryConfig
 }


### PR DESCRIPTION
# Description

Currently, we are fetching the `discoveryconfig` credential based on the `discoveryconfig` that is reconciled. This is leading to the wrong credential being used for the imported `discoveredcluster`. This PR will look for the `secret` associated with the `discoveredcluster` resource.

## Related Issue

https://issues.redhat.com/browse/ACM-10996

## Changes Made

Update secret flow from getting `discoveryconfig.spec.credential` to `discoveredcluster.spec.credential`

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
