### PR TITLE
[ACM-12690] Updated discovery webhook string validation

### DIFF
--- a/api/v1/discovery_webhook.go
+++ b/api/v1/discovery_webhook.go
@@ -174,6 +174,6 @@ func IsSupportedClusterType(clusterType string) bool {
 
 // IsStringValid returns true if the string conforms to the RFC 1123 standards.
 func IsStringValid(s string) bool {
-	re := regexp.MustCompile(`^[a-zA-Z0-9.-]+$`)
+	re := regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
 	return re.MatchString(s)
 }

--- a/api/v1/discovery_webhook.go
+++ b/api/v1/discovery_webhook.go
@@ -120,7 +120,7 @@ func (r *DiscoveredCluster) ValidateCreate() (admission.Warnings, error) {
 	if !IsStringValid(r.Spec.DisplayName) && r.Spec.ImportAsManagedCluster {
 		err := fmt.Errorf(
 			"cannot update DiscoveredCluster '%s': importAsManagedCluster is not allowed for clusters with an invalid display name '%s'. "+
-				"Display name must consist of lowercase alphanumeric characters, '-' or '.'", r.Name, r.Spec.DisplayName)
+				"Display name must consist of lowercase alphanumeric characters or '-'", r.Name, r.Spec.DisplayName)
 
 		discoveredclusterLog.Error(err, "validation failed")
 		return nil, err
@@ -147,7 +147,7 @@ func (r *DiscoveredCluster) ValidateUpdate(old runtime.Object) (admission.Warnin
 	if !IsStringValid(r.Spec.DisplayName) && r.Spec.ImportAsManagedCluster {
 		err := fmt.Errorf(
 			"cannot update DiscoveredCluster '%s': importAsManagedCluster is not allowed for clusters with an invalid display name '%s'. "+
-				"Display name must consist of lowercase alphanumeric characters, '-' or '.'", r.Name, r.Spec.DisplayName)
+				"Display name must consist of lowercase alphanumeric characters or '-'", r.Name, r.Spec.DisplayName)
 
 		discoveredclusterLog.Error(err, "validation failed")
 		return nil, err


### PR DESCRIPTION
# Description

Updated Discovery webhook regex string to exclude `'.'` characters.

## Related Issue

https://issues.redhat.com/browse/ACM-12690

## Changes Made

Updated Discovery webhook to exclude `'.'` as a valid string character for DiscoveredCluster `displayName`.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
