### PR TITLE
[ACM-13054] Added sample service-account authentication secret

### DIFF
--- a/config/samples/ocm-api-secret.yaml
+++ b/config/samples/ocm-api-secret.yaml
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 apiVersion: v1
-data:
+stringData:
   auth_method: offline-token
   ocmAPIToken: ENCRYPTED_TOKEN
 kind: Secret

--- a/config/samples/ocm-api-secret.yaml
+++ b/config/samples/ocm-api-secret.yaml
@@ -2,6 +2,7 @@
 
 apiVersion: v1
 data:
+  auth_method: offline-token
   ocmAPIToken: ENCRYPTED_TOKEN
 kind: Secret
 metadata:

--- a/config/samples/ocm-api-serviceaccount.yaml
+++ b/config/samples/ocm-api-serviceaccount.yaml
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 apiVersion: v1
-data:
+stringData:
   auth_method: service-account
   client_id: ENCRYPTED_CLIENT_ID
   client_secret: ENCRYPTED_CLIENT_SECRET

--- a/config/samples/ocm-api-serviceaccount.yaml
+++ b/config/samples/ocm-api-serviceaccount.yaml
@@ -1,0 +1,15 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+data:
+  auth_method: service-account
+  client_id: ENCRYPTED_CLIENT_ID
+  client_secret: ENCRYPTED_CLIENT_SECRET
+kind: Secret
+metadata:
+  labels:
+    cluster.open-cluster-management.io/credentials: ''
+    cluster.open-cluster-management.io/type: rhocm
+  name: ocm-api-service-account
+  namespace: NAMESPACE
+type: Opaque


### PR DESCRIPTION
# Description

As we prepare for the transition of moving away from OCM offline tokens for discovery, we will begin supporting OCM service accounts for authenticating users to discover clusters from OCM.

## Related Issue

https://issues.redhat.com/browse/ACM-13054

## Changes Made

Added sample service account secret for discovery.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
