### PR TITLE
Add service-account credentials into auto-import-secret.

### DIFF
--- a/controllers/discoveredcluster_controller_test.go
+++ b/controllers/discoveredcluster_controller_test.go
@@ -266,10 +266,43 @@ func Test_Reconciler_CreateAutoImportSecret(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := r.CreateAutoImportSecret(tt.nn, tt.clusterID, tt.token)
+			s := r.CreateAutoImportSecretOfflineToken(tt.nn, tt.clusterID, tt.token)
 
 			if got := s.GetName() != tt.nn.Name; got {
 				t.Errorf("CreateAutoImportSecret(tt.nn) = want %v, got %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_Reconciler_CreateAutoImportSecretServiceAccount(t *testing.T) {
+	tests := []struct {
+		name         string
+		clusterID    string
+		nn           types.NamespacedName
+		clientID     string
+		clientSecret string
+		want         bool
+	}{
+		{
+			name:      "should create auto import Secret object",
+			clusterID: "BASS9-ADJAN-349AS-923SD",
+			nn: types.NamespacedName{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			clientID:     "sample-client-id",
+			clientSecret: "sample-client-secret",
+			want:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := r.CreateAutoImportSecretServiceAccount(tt.nn, tt.clusterID, tt.clientID, tt.clientSecret)
+
+			if got := s.GetName() != tt.nn.Name; got {
+				t.Errorf("CreateAutoImportSecretServiceAccount(tt.nn) = want %v, got %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
# Description

This PR add the new OCM auth method credentials "client_id" and "client_secret" into auto-import-secret to let import-controller get the cluster details.

## Related Issue

This PR is to support Jira issue: https://issues.redhat.com/browse/ACM-10404 which is related to https://issues.redhat.com/browse/ACM-13056

## Changes Made

Add the service-account authentication method also into auto-import-secret.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
