### PR TITLE
[ACM-14671] Remove DiscoveredClusters resources on unauthorized client error

### DIFF
--- a/pkg/ocm/auth/provider.go
+++ b/pkg/ocm/auth/provider.go
@@ -19,7 +19,8 @@ var (
 	httpClient   AuthPostInterface = &authRestClient{}
 	AuthProvider IAuthProvider     = &authProvider{}
 
-	ErrInvalidToken = errors.New("invalid token")
+	ErrInvalidToken       = errors.New("invalid token")
+	ErrUnauthorizedClient = errors.New("unauthorized_client")
 )
 
 type AuthPostInterface interface {

--- a/pkg/ocm/auth/service.go
+++ b/pkg/ocm/auth/service.go
@@ -25,8 +25,9 @@ func (client authClient) GetToken(request AuthRequest) (string, error) {
 	response, err := AuthProvider.GetToken(request)
 
 	if err != nil {
-		return "", fmt.Errorf("%s: %w", "couldn't get token", err.Error)
+		return "", fmt.Errorf("%s: %v", "couldn't get token", err)
 	}
+
 	if response.AccessToken == "" {
 		return "", fmt.Errorf("missing `access_token` in response")
 	}

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -87,6 +87,11 @@ func formatCluster(sub subscription.Subscription) (discovery.DiscoveredCluster, 
 	return discoveredCluster, true
 }
 
+// IsUnauthorizedClient returns true if the specified error is unauthorized client side error.
+func IsUnauthorizedClient(err error) bool {
+	return strings.Contains(err.Error(), auth.ErrUnauthorizedClient.Error())
+}
+
 // IsUnrecoverable returns true if the specified error is not temporary
 // and will continue to occur with the current state.
 func IsUnrecoverable(err error) bool {


### PR DESCRIPTION
# Description

Updated the `discovery-operator` to remove the `DiscoveredCluster` resources if the client request is unauthorized.

## Related Issue

https://issues.redhat.com/browse/ACM-14671

## Changes Made

Updated operator to remove `DiscoveredCluster` instances if an unauthorized client error is received.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [x] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
