### PR TITLE
Fixed renovate.json file name

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "addLabels": ["ok-to-test"],
-    "baseBranches": ["/(^main$)|(^backplane-2\\.(4|5|6)$)/"],
+    "baseBranches": ["/(^main$)|(^backplane-2\\.(4|5|6|7)$)/"],
     "rebaseWhen": "behind-base-branch",
     "recreateWhen": "never",
     "schedule": ["before 8am on tuesday and thursday"],


### PR DESCRIPTION
# Description

When adding the `renovate.json` file to the repo, the filename was incorrectly spelled which led to the konflux jobs not working as intended. This PR will correct the filename in order for the konflux jobs to properly run on the desired schedule.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated `.github/renovat.json` to `.github/renovate.json`

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
