### PR TITLE
[ACM-15010] Added error condition for invalid client id

### DIFF
--- a/controllers/discoveryconfig_controller.go
+++ b/controllers/discoveryconfig_controller.go
@@ -158,7 +158,7 @@ func (r *DiscoveryConfigReconciler) updateDiscoveredClusters(ctx context.Context
 	}
 
 	if err != nil {
-		if ocm.IsUnrecoverable(err) || ocm.IsUnauthorizedClient(err) {
+		if ocm.IsUnrecoverable(err) || ocm.IsUnauthorizedClient(err) || ocm.IsInvalidClient(err) {
 			logf.Info("Error encountered. Cleaning up clusters.", "Error", err.Error())
 			return r.deleteAllClusters(ctx, config)
 		}

--- a/pkg/ocm/auth/provider.go
+++ b/pkg/ocm/auth/provider.go
@@ -20,6 +20,7 @@ var (
 	AuthProvider IAuthProvider     = &authProvider{}
 
 	ErrInvalidToken       = errors.New("invalid token")
+	ErrInvalidClient      = errors.New("invalid_client")
 	ErrUnauthorizedClient = errors.New("unauthorized_client")
 )
 

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -86,6 +86,14 @@ func formatCluster(sub subscription.Subscription) (discovery.DiscoveredCluster, 
 	return discoveredCluster, true
 }
 
+// IsInvalidClient returns true if the specified error is invalid client side error.
+func IsInvalidClient(err error) bool {
+	if err != nil {
+		return strings.Contains(err.Error(), auth.ErrInvalidClient.Error())
+	}
+	return false
+}
+
 // IsUnauthorizedClient returns true if the specified error is unauthorized client side error.
 func IsUnauthorizedClient(err error) bool {
 	if err != nil {

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -338,6 +338,38 @@ func Test_IsRecoverable(t *testing.T) {
 
 }
 
+func Test_IsInvalidClient(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "Unrecoverable Invalid Client Error",
+			err:  auth.ErrInvalidClient,
+			want: true,
+		},
+		{
+			name: "Recoverable Error",
+			err:  errors.New("test error"),
+			want: false,
+		},
+		{
+			name: "Empty Error",
+			err:  nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsInvalidClient(tt.err); got != tt.want {
+				t.Errorf("IsInvalidClient() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}
+
 // BOOKMARK: This is the test for No ExternalClusterID
 func TestFormatCLusterError(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
# Description

When a user has an invalid client ID, the `discovery-operator` is not removing any `DiscoveredCluster` resources from the console. This PR will add a new error condition for a `invalid_client` and remove any `DiscoveredCluster` resource from the cluster.

```bash
2024-10-23T14:24:44.803Z ERROR reconcile Error updating DiscoveredClusters {"error": "couldn't get token: &{401 invalid_client Invalid client or Invalid client credentials <nil> []}"}
```

## Related Issue

https://issues.redhat.com/browse/ACM-15010

## Changes Made

Added new error condition for `invalid_client`.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
