### PR TITLE
[ACM-15113] Updated Discovery secret watcher to watch for multiple DiscoveryConfigs

### DIFF
--- a/controllers/discoveryconfig_controller.go
+++ b/controllers/discoveryconfig_controller.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	defaultDiscoveryConfigName = "discovery"
+	DefaultDiscoveryConfigName = "discovery"
 )
 
 var logf = log.Log.WithName("reconcile")
@@ -218,12 +218,12 @@ func (r *DiscoveryConfigReconciler) updateDiscoveredClusters(ctx context.Context
 
 /*
 ValidateDiscoveryConfigName validates the name of the DiscoveryConfig resource.
-It ensures that the provided name matches the defaultDiscoveryConfigName.
+It ensures that the provided name matches the DefaultDiscoveryConfigName.
 */
 func (r *DiscoveryConfigReconciler) validateDiscoveryConfigName(reqName string) error {
-	if reqName != defaultDiscoveryConfigName {
+	if reqName != DefaultDiscoveryConfigName {
 		return fmt.Errorf("invalid DiscoveryConfig resource name '%s', it must be '%s'",
-			reqName, defaultDiscoveryConfigName)
+			reqName, DefaultDiscoveryConfigName)
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

Updated the `discovery-operator` watcher to look at multiple `DiscoveryConfig` secret, instead of one.

## Related Issue

https://issues.redhat.com/browse/ACM-15113

## Changes Made

Updated watcher logic to fetch the latest `DiscoveryConfigs` and watch for `update` and `delete` events for secrets.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
