### PR TITLE
[ACM-16356] Removed limits for discovery deployments

### DIFF
--- a/bundle/manifests/discovery.clusterserviceversion.yaml
+++ b/bundle/manifests/discovery.clusterserviceversion.yaml
@@ -259,9 +259,6 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources:
-                  limits:
-                    cpu: 300m
-                    memory: 1Gi
                   requests:
                     cpu: 100m
                     memory: 100Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,9 +55,6 @@ spec:
         - containerPort: 8080
           name: metrics
         resources:
-          limits:
-            cpu: 300m
-            memory: 1Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/testserver/build/local-server/deploy.yaml
+++ b/testserver/build/local-server/deploy.yaml
@@ -27,6 +27,3 @@ spec:
           requests:
             memory: "64Mi"
             cpu: "250m"
-          limits:
-            memory: "128Mi"
-            cpu: "500m"


### PR DESCRIPTION
# Description

For this release, we are removing the resource `limits` specified in the operators/controllers deployment configuration. This change is intended to test and optimize resource consumption across clusters of various sizes for our customers.

## Related Issue

https://issues.redhat.com/browse/ACM-16356

## Changes Made

Removed resource limits from the Discovery deployment YAML configuration.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @gparvin 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
