### PR TITLE
[ACM-18825] Optimized search parameters for Discovery when querying OCM for subscription data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
-CONTROLLER_TOOLS_VERSION ?= v0.10.0
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,6 @@
 domain: open-cluster-management.io
 layout:
-- go.kubebuilder.io/v3
+- go.kubebuilder.io/v4
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}

--- a/api/v1/discoveryconfig_types.go
+++ b/api/v1/discoveryconfig_types.go
@@ -21,8 +21,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Filter ...
+// Filter defines the criteria for discovering clusters based on specific attributes.
 type Filter struct {
+	// ClusterTypes is the list of cluster types to discover. These types represent the platform
+	// the cluster is running on, such as OpenShift Container Platform (OCP), Azure Red Hat OpenShift (ARO),
+	// or others.
+	// +optional
+	ClusterTypes []string `json:"clusterTypes,omitempty"`
+
+	// InfrastructureProviders is the list of infrastructure providers to discover. This can be
+	// a list of cloud providers or platforms (e.g., AWS, Azure, GCP) where clusters might be running.
+	// +optional
+	InfrastructureProviders []string `json:"infrastructureProviders,omitempty"`
+
 	// LastActive is the last active in days of clusters to discover, determined by activity timestamp
 	// +optional
 	LastActive int `json:"lastActive,omitempty"`
@@ -30,6 +41,12 @@ type Filter struct {
 	// OpenShiftVersions is the list of release versions of OpenShift of the form "<Major>.<Minor>"
 	// +optional
 	OpenShiftVersions []Semver `json:"openShiftVersions,omitempty"`
+
+	// Regions is the list of regions where OpenShift clusters are located. This helps in filtering
+	// clusters based on geographic location or data center region, useful for compliance or latency
+	// requirements.
+	// +optional
+	Regions []string `json:"regions,omitempty"`
 }
 
 // Semver represents a partial semver string with the major and minor version

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,9 +6,9 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=discovery
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.39.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/manifests/discovery.clusterserviceversion.yaml
+++ b/bundle/manifests/discovery.clusterserviceversion.yaml
@@ -21,13 +21,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Integration & Delivery
-    createdAt: "2024-10-10T16:27:01Z"
+    createdAt: "2025-03-25T14:43:30Z"
     description: This operator discovers OpenShift Conatiner Platform clusters which
       are not yet under management by Open Cluster Management.
     operatorframework.io/suggested-namespace: open-cluster-management
-    operators.operatorframework.io/builder: operator-sdk-v1.37.0
+    operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: '["discoveredclusters.discovery.open-cluster-management.io"]'
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     support: Red Hat
   name: discovery.v0.0.1
   namespace: placeholder

--- a/bundle/manifests/discovery.open-cluster-management.io_discoveryconfigs.yaml
+++ b/bundle/manifests/discovery.open-cluster-management.io_discoveryconfigs.yaml
@@ -46,6 +46,21 @@ spec:
               filters:
                 description: Sets restrictions on what kind of clusters to discover
                 properties:
+                  clusterTypes:
+                    description: |-
+                      ClusterTypes is the list of cluster types to discover. These types represent the platform
+                      the cluster is running on, such as OpenShift Container Platform (OCP),
+                      Azure Red Hat OpenShift (ARO), or others.
+                    items:
+                      type: string
+                    type: array
+                  infrastructureProviders:
+                    description: |-
+                      InfrastructureProviders is the list of infrastructure providers to discover. This can be
+                      a list of cloud providers or platforms (e.g., AWS, Azure, GCP) where clusters might be running.
+                    items:
+                      type: string
+                    type: array
                   lastActive:
                     description: LastActive is the last active in days of clusters
                       to discover, determined by activity timestamp
@@ -58,6 +73,14 @@ spec:
                         Semver represents a partial semver string with the major and minor version
                         in the form "<Major>.<Minor>". For example: "4.5"
                       pattern: ^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$
+                      type: string
+                    type: array
+                  regions:
+                    description: |-
+                      Regions is the list of regions where OpenShift clusters are located. This helps in filtering
+                      clusters based on geographic location or data center region, useful for compliance or latency
+                      requirements.
+                    items:
                       type: string
                     type: array
                 type: object

--- a/bundle/manifests/discovery.open-cluster-management.io_discoveryconfigs.yaml
+++ b/bundle/manifests/discovery.open-cluster-management.io_discoveryconfigs.yaml
@@ -49,8 +49,8 @@ spec:
                   clusterTypes:
                     description: |-
                       ClusterTypes is the list of cluster types to discover. These types represent the platform
-                      the cluster is running on, such as OpenShift Container Platform (OCP),
-                      Azure Red Hat OpenShift (ARO), or others.
+                      the cluster is running on, such as OpenShift Container Platform (OCP), Azure Red Hat OpenShift (ARO),
+                      or others.
                     items:
                       type: string
                     type: array

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,9 +5,9 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: discovery
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.37.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.39.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/crd/bases/discovery.open-cluster-management.io_discoveryconfigs.yaml
+++ b/config/crd/bases/discovery.open-cluster-management.io_discoveryconfigs.yaml
@@ -46,6 +46,21 @@ spec:
               filters:
                 description: Sets restrictions on what kind of clusters to discover
                 properties:
+                  clusterTypes:
+                    description: |-
+                      ClusterTypes is the list of cluster types to discover. These types represent the platform
+                      the cluster is running on, such as OpenShift Container Platform (OCP), Azure Red Hat OpenShift (ARO),
+                      or others.
+                    items:
+                      type: string
+                    type: array
+                  infrastructureProviders:
+                    description: |-
+                      InfrastructureProviders is the list of infrastructure providers to discover. This can be
+                      a list of cloud providers or platforms (e.g., AWS, Azure, GCP) where clusters might be running.
+                    items:
+                      type: string
+                    type: array
                   lastActive:
                     description: LastActive is the last active in days of clusters
                       to discover, determined by activity timestamp
@@ -58,6 +73,14 @@ spec:
                         Semver represents a partial semver string with the major and minor version
                         in the form "<Major>.<Minor>". For example: "4.5"
                       pattern: ^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$
+                      type: string
+                    type: array
+                  regions:
+                    description: |-
+                      Regions is the list of regions where OpenShift clusters are located. This helps in filtering
+                      clusters based on geographic location or data center region, useful for compliance or latency
+                      requirements.
+                    items:
                       type: string
                     type: array
                 type: object

--- a/licensetest/license_test.go
+++ b/licensetest/license_test.go
@@ -19,6 +19,7 @@ var poundScanner = regexp.MustCompile(`\# Copyright Contributors to the Open Clu
 var skip = map[string]bool{
 	"../api/v1alpha1/zz_generated.deepcopy.go": true, // Generated file
 	"../api/v1/zz_generated.deepcopy.go":       true, // Generated file
+	"../.venv":                                 true, // Generated file
 }
 
 func TestLicense(t *testing.T) {

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -52,12 +52,7 @@ func formatCluster(sub subscription.Subscription) (discovery.DiscoveredCluster, 
 	if len(sub.Metrics) == 0 {
 		return discoveredCluster, false
 	}
-	if sub.ExternalClusterID == "" {
-		return discoveredCluster, false
-	}
-	if sub.Status == "Reserved" {
-		return discoveredCluster, false
-	}
+
 	discoveredCluster = discovery.DiscoveredCluster{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "operator.open-cluster-management.io/v1",

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -11,7 +11,6 @@ import (
 	discovery "github.com/stolostron/discovery/api/v1"
 	"github.com/stolostron/discovery/pkg/ocm/auth"
 	"github.com/stolostron/discovery/pkg/ocm/subscription"
-	sub "github.com/stolostron/discovery/pkg/ocm/subscription"
 )
 
 var (
@@ -367,45 +366,4 @@ func Test_IsInvalidClient(t *testing.T) {
 			}
 		})
 	}
-
-}
-
-// BOOKMARK: This is the test for No ExternalClusterID
-func TestFormatCLusterError(t *testing.T) {
-	tests := []struct {
-		name string
-		sub  sub.Subscription
-		dc   discovery.DiscoveredCluster
-		want bool
-	}{
-		{
-			name: "No ExternalClusterID",
-			sub: sub.Subscription{
-				ExternalClusterID: "",
-				DisplayName:       "my-custom-name",
-				Metrics:           []sub.Metrics{{OpenShiftVersion: "4.8.5"}},
-			},
-			dc:   discovery.DiscoveredCluster{},
-			want: false,
-		},
-		{
-			name: "Reserved Cluster Status",
-			sub: sub.Subscription{
-				ExternalClusterID: "exists",
-				DisplayName:       "my-custom-name",
-				Status:            "Reserved",
-				Metrics:           []sub.Metrics{{OpenShiftVersion: "4.8.5"}},
-			},
-			dc:   discovery.DiscoveredCluster{},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if _, got := formatCluster(tt.sub); got != tt.want {
-				t.Errorf("formatCluster() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-
 }

--- a/pkg/ocm/subscription/provider.go
+++ b/pkg/ocm/subscription/provider.go
@@ -71,14 +71,34 @@ func (c *subscriptionProvider) GetSubscriptions(request SubscriptionRequest) (re
 func prepareRequest(request SubscriptionRequest) (*http.Request, error) {
 	getURL := fmt.Sprintf(subscriptionURL, request.BaseURL)
 	query := &url.Values{}
-	query.Add("size", fmt.Sprintf("%d", request.Size))
 	query.Add("page", fmt.Sprintf("%d", request.Page))
+	query.Add("size", fmt.Sprintf("%d", request.Size))
+
+	/*
+		In Red Hat OpenShift Cluster Manager (OCM), when users access console.redhat.com/openshift/cluster-list,
+		OCM applies several filters before returning the data to the console. In previous releases,
+		we fetched all cluster subscription data, which resulted in performance bottlenecks for our components.
+
+		With MCE 2.9, we are introducing additional pre-filters to refine the data sent to OCM,
+		ensuring that only the necessary information is requested. Below is the filter that OCM applies:
+
+		(cluster_id!='') AND (plan.id IN ('OSD', 'OSDTrial', 'OCP', 'RHMI', 'ROSA', 'RHOIC', 'MOA',
+		'MOA-HostedControlPlane', 'ROSA-HyperShift', 'ARO', 'OCP-AssistedInstall')) AND (
+		status NOT IN ('Deprovisioned', 'Archived')) AND (
+		display_name is not null OR external_cluster_id is not null OR cluster_id is not null)
+	*/
+	query.Add("orderBy", "created_at desc")
+	query.Add("search", "status NOT IN ('Deprovisioned', 'Archived', 'Reserved')")
+	query.Add("search", "external_cluster_id is not null")
+
 	applyPreFilters(query, request.Filter)
+	logf.V(1).Info("Request", "Query", query)
 
 	getRequest, err := http.NewRequest("GET", getURL, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	getRequest.URL.RawQuery = query.Encode()
 	getRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", request.Token))
 	getRequest = getRequest.WithContext(context.Background())


### PR DESCRIPTION
# Description

In previous releases, Discovery did not apply any pre-filters when making requests to OCM. As a result, subscription data requests retrieved all available data rather than only the relevant information for Discovery. This PR introduces additional pre-filters, similar to those used in the OCM console, to enhance data integrity and optimize Discovery's search parameters.

Additionally, this PR introduces new filtering options in the `DiscoveryConfig`, allowing users to refine their `DiscoveredCluster` resources within their cluster environments. The new filters include `infrastructureProviders`, `regions`, and `clusterTypes`.

## Related Issue

https://issues.redhat.com/browse/ACM-18825

## Changes Made

Updated search parameters for client requests to OCM. Added new filters options in the `DiscoveryConfig` resource.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
