### PR TITLE
[ACM-18825] Optimized search parameters for Discovery when querying OCM for subscription data

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -52,12 +52,7 @@ func formatCluster(sub subscription.Subscription) (discovery.DiscoveredCluster, 
 	if len(sub.Metrics) == 0 {
 		return discoveredCluster, false
 	}
-	if sub.ExternalClusterID == "" {
-		return discoveredCluster, false
-	}
-	if sub.Status == "Reserved" {
-		return discoveredCluster, false
-	}
+
 	discoveredCluster = discovery.DiscoveredCluster{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "operator.open-cluster-management.io/v1",

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -11,7 +11,6 @@ import (
 	discovery "github.com/stolostron/discovery/api/v1"
 	"github.com/stolostron/discovery/pkg/ocm/auth"
 	"github.com/stolostron/discovery/pkg/ocm/subscription"
-	sub "github.com/stolostron/discovery/pkg/ocm/subscription"
 )
 
 var (
@@ -364,46 +363,6 @@ func Test_IsInvalidClient(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsInvalidClient(tt.err); got != tt.want {
 				t.Errorf("IsInvalidClient() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-
-}
-
-// BOOKMARK: This is the test for No ExternalClusterID
-func TestFormatCLusterError(t *testing.T) {
-	tests := []struct {
-		name string
-		sub  sub.Subscription
-		dc   discovery.DiscoveredCluster
-		want bool
-	}{
-		{
-			name: "No ExternalClusterID",
-			sub: sub.Subscription{
-				ExternalClusterID: "",
-				DisplayName:       "my-custom-name",
-				Metrics:           []sub.Metrics{{OpenShiftVersion: "4.8.5"}},
-			},
-			dc:   discovery.DiscoveredCluster{},
-			want: false,
-		},
-		{
-			name: "Reserved Cluster Status",
-			sub: sub.Subscription{
-				ExternalClusterID: "exists",
-				DisplayName:       "my-custom-name",
-				Status:            "Reserved",
-				Metrics:           []sub.Metrics{{OpenShiftVersion: "4.8.5"}},
-			},
-			dc:   discovery.DiscoveredCluster{},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if _, got := formatCluster(tt.sub); got != tt.want {
-				t.Errorf("formatCluster() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/ocm/subscription/provider.go
+++ b/pkg/ocm/subscription/provider.go
@@ -71,14 +71,34 @@ func (c *subscriptionProvider) GetSubscriptions(request SubscriptionRequest) (re
 func prepareRequest(request SubscriptionRequest) (*http.Request, error) {
 	getURL := fmt.Sprintf(subscriptionURL, request.BaseURL)
 	query := &url.Values{}
-	query.Add("size", fmt.Sprintf("%d", request.Size))
 	query.Add("page", fmt.Sprintf("%d", request.Page))
+	query.Add("size", fmt.Sprintf("%d", request.Size))
+
+	/*
+		In Red Hat OpenShift Cluster Manager (OCM), when users access console.redhat.com/openshift/cluster-list,
+		OCM applies several filters before returning the data to the console. In previous releases,
+		we fetched all cluster subscription data, which resulted in performance bottlenecks for our components.
+
+		With MCE 2.9, we are introducing additional pre-filters to refine the data sent to OCM,
+		ensuring that only the necessary information is requested. Below is the filter that OCM applies:
+
+		(cluster_id!='') AND (plan.id IN ('OSD', 'OSDTrial', 'OCP', 'RHMI', 'ROSA', 'RHOIC', 'MOA',
+		'MOA-HostedControlPlane', 'ROSA-HyperShift', 'ARO', 'OCP-AssistedInstall')) AND (
+		status NOT IN ('Deprovisioned', 'Archived')) AND (
+		display_name is not null OR external_cluster_id is not null OR cluster_id is not null)
+	*/
+	query.Add("orderBy", "created_at desc")
+	query.Add("search", "status NOT IN ('Deprovisioned', 'Archived', 'Reserved')")
+	query.Add("search", "external_cluster_id is not null")
+
 	applyPreFilters(query, request.Filter)
+	logf.V(1).Info("Request", "Query", query)
 
 	getRequest, err := http.NewRequest("GET", getURL, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	getRequest.URL.RawQuery = query.Encode()
 	getRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", request.Token))
 	getRequest = getRequest.WithContext(context.Background())

--- a/pkg/ocm/subscription/provider.go
+++ b/pkg/ocm/subscription/provider.go
@@ -92,7 +92,7 @@ func prepareRequest(request SubscriptionRequest) (*http.Request, error) {
 	query.Add("search", "external_cluster_id is not null")
 
 	applyPreFilters(query, request.Filter)
-	logf.V(1).Info("Request", "Query", query)
+	// logf.V(1).Info("Request", "Query", query)
 
 	getRequest, err := http.NewRequest("GET", getURL, nil)
 	if err != nil {


### PR DESCRIPTION
# Description

In previous releases, Discovery did not apply any pre-filters when making requests to OCM. As a result, subscription data requests retrieved all available data rather than only the relevant information for Discovery. This PR introduces additional pre-filters, similar to those used in the OCM console, to enhance data integrity and optimize Discovery's search parameters.

Additionally, this PR introduces new filtering options in the `DiscoveryConfig`, allowing users to refine their `DiscoveredCluster` resources within their cluster environments. The new filters include `infrastructureProviders`, `regions`, and `clusterTypes`.

## Related Issue

https://issues.redhat.com/browse/ACM-18825

## Changes Made

Updated search parameters for client requests to OCM. Added new filters options in the `DiscoveryConfig` resource.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
