### PR TITLE
[ACM-14776] Updated discoveredcluster apply logic to pass importAsManagedCluster field

### DIFF
--- a/controllers/discoveryconfig_controller.go
+++ b/controllers/discoveryconfig_controller.go
@@ -344,16 +344,23 @@ func (r *DiscoveryConfigReconciler) applyCluster(ctx context.Context, config *di
 		return r.createCluster(ctx, config, dc)
 	}
 
+	/*
+		In MCE 2.6, we introduced a feature that allows discovered cluster resources to be automatically imported when
+		the importAsManagedCluster field is set to true. Since this field is not included in the subscription data when
+		querying OCM, we must ensure that the discovered cluster resource retains the importAsManagedCluster status
+		from the original discovered cluster. This is necessary because the field is internally defined and not part
+		of OCM's data.
+
+		To ensure proper functionality, we need to pass the value before determining if the cluster requires an update.
+		Otherwise, the cluster will always be marked for update, as the field is not present in the most recent
+		discovered cluster specification.
+	*/
+	dc.Spec.ImportAsManagedCluster = current.Spec.ImportAsManagedCluster
+
 	if dc.Equal(current) {
 		// Discovered cluster has not changed
 		return nil
 	}
-
-	/*
-		Ensure the discovered cluster resource from OCM retains the importAsManagedCluster status from the existing
-		cluster, as this field is internally defined and not included in OCM's data.
-	*/
-	dc.Spec.ImportAsManagedCluster = current.Spec.ImportAsManagedCluster
 
 	// Cluster needs to be updated
 	return r.updateCluster(ctx, dc, current)

--- a/controllers/discoveryconfig_controller.go
+++ b/controllers/discoveryconfig_controller.go
@@ -349,6 +349,12 @@ func (r *DiscoveryConfigReconciler) applyCluster(ctx context.Context, config *di
 		return nil
 	}
 
+	/*
+		Ensure the discovered cluster resource from OCM retains the importAsManagedCluster status from the existing
+		cluster, as this field is internally defined and not included in OCM's data.
+	*/
+	dc.Spec.ImportAsManagedCluster = current.Spec.ImportAsManagedCluster
+
 	// Cluster needs to be updated
 	return r.updateCluster(ctx, dc, current)
 }


### PR DESCRIPTION
# Description

In MCE 2.6, we introduced a feature that automatically imports discovered cluster resources when the `importAsManagedCluster` field is set to `true`. However, since this field is not included in the subscription data when querying OCM, we need to ensure that the `importAsManagedCluster` status is retained from the original discovered cluster resource.

This PR ensures that the `importAsManagedCluster` field is properly handled and avoids unnecessary updates.

## Related Issue

https://issues.redhat.com/browse/ACM-14776

## Changes Made

Updated `discoveryconfig` controller to pass the `importAsManagedCluster` field for preexisting discovered cluster resources.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
