### PR TITLE
[backplane-2.7] Updated slack-member-id for tekton push config

### DIFF
--- a/.tekton/discovery-operator-mce-27-push.yaml
+++ b/.tekton/discovery-operator-mce-27-push.yaml
@@ -43,7 +43,7 @@ spec:
   - name: konflux-application-name
     value: release-mce-27
   - name: slack-member-id
-    value: S05L3R4SM89 # @acm-hub-install-ic, The slack member id of the current component owner.
+    value: UU77A0LC8 # @dbennett, The slack member id of the current component owner.
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
# Description

In the current pipeline workflow, Konflux does not support group user IDs when sending Slack notifications. This PR updates the configuration to use a user ID instead of a group ID.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated `.tekton/*-push.yaml` files to replace group ID with user ID.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
