### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for discovery-operator-mce-29

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -25,6 +25,7 @@ LABEL org.label-schema.vendor="Red Hat" \
       io.k8s.display-name="MultiClusterEngine operator" \
       io.k8s.description="Operator for managing discovered clusters from OpenShift Cluster Manager" \
       com.redhat.component="multicluster-engine-discovery-operator-container" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       io.openshift.tags="data,images"
 
 WORKDIR /


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
