### PR TITLE
Add repository url label to container images

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -17,6 +17,7 @@ RUN CGO_ENABLED=1 go build -mod=readonly -o manager main.go
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL org.label-schema.vendor="Red Hat" \
+      url="https://github.com/stolostron/discovery" \
       org.label-schema.name="discovery-operator" \
       org.label-schema.description="Operator for managing discovered clusters from OpenShift Cluster Manager" \
       name="multicluster-engine/discovery-rhel9" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** backplane-2.10

**Components affected:** discovery-operator

**Branch details:** discovery-operator (branch: backplane-2.10)

**Label added:**
- url: https://github.com/stolostron/discovery

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.