### PR TITLE
[ACM-32357] Disable WatchListClient to fix cache sync timeouts

### DIFF
--- a/bundle/manifests/discovery.clusterserviceversion.yaml
+++ b/bundle/manifests/discovery.clusterserviceversion.yaml
@@ -219,6 +219,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: KUBE_FEATURE_WatchListClient
+                  value: "false"
                 image: discovery-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBE_FEATURE_WatchListClient
+          value: "false"
         image: controller:latest
         imagePullPolicy: Always
         name: discovery-operator


### PR DESCRIPTION
## Description

This PR fixes controller cache sync timeout errors caused by the
WatchListClient feature in Kubernetes client-go v0.35.3. The operator
was failing to start due to missing bookmark events required by the
new WatchList semantics.

## Related Issue

https://redhat.atlassian.net/browse/ACM-32357

## Changes Made

- Added KUBE_FEATURE_WatchListClient=false environment variable to the
  discovery-operator deployment in config/manager/manager.yaml
- Updated bundle/manifests/discovery.clusterserviceversion.yaml with
  the same environment variable to ensure consistency

This disables the WatchListClient feature and falls back to the
traditional List+Watch pattern, which resolves the cache sync timeout
errors with the following controllers:
- discoveryconfig
- discoveredcluster  
- managedcluster

## Root Cause

After merging upstream changes that updated k8s.io packages from v0.31.0
to v0.35.3, the WatchListClient feature became enabled by default. This
feature requires the Kubernetes API server to send bookmark events with
k8s.io/initial-events-end: "true" annotation. When these events are not
received within 2 minutes, the reflector times out causing cache sync
failures.

Error symptoms:
- "awaiting required bookmark event for initial events stream"
- "failed to wait for caches to sync: timed out waiting for cache to be synced"
- All three controllers (discoveryconfig, discoveredcluster, managedcluster) failing to start

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This is a temporary workaround for a known issue with client-go v0.35.x
and WatchList feature. Future solutions may include:
- Upgrading Kubernetes cluster to ensure proper bookmark event support
- Waiting for upstream fixes in kubernetes/kubernetes issues #135895, #126958
- Reverting to client-go v0.31.0 if necessary

References:
- https://github.com/kubernetes/kubernetes/issues/135895
- https://github.com/gravitational/teleport/issues/64188
- https://github.com/kubernetes/kubernetes/issues/126958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added feature flag configuration settings to discovery-operator deployment across multiple configuration files. These updates enhance operational control and runtime consistency for the discovery-operator component. Configuration changes applied to both cluster service version manifest and manager settings to ensure uniform behavior across deployment environments and support ongoing operational requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->