### PR TITLE
[backplane-2.7] Update Go to 1.25.8 to fix CVE-2026-25679

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Operator for managing discovered clusters from OpenShift Cluster Manager
 
 ## Prerequisites
 
-- Go v1.24+
+- Go v1.25.8+
 - kubectl 1.21+
 - Operator-sdk v1.22.2
 - Docker

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/discovery
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
# Description

Update Go version from 1.25.7 to 1.25.8 to address CVE-2026-25679.

## Related Issue

https://issues.redhat.com/browse/ACM-31125

## Changes Made

- Updated go.mod to specify Go 1.25.8
- Ran go mod tidy to update dependencies

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This update addresses CVE-2026-25679 in the Go stdlib net/url package.
CVE-2026-32280 still requires Go 1.25.9 which is not yet available.