### PR TITLE
[backplane-2.11] Update Go to 1.25.8 to fix CVE-2026-25679

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Use toolchain from go.mod so Go uses a complete install (with covdata); avoids
+# "no such tool covdata" when auto-downloaded minimal toolchain is used (golang/go#75031).
+GOTOOLCHAIN ?= $(shell (grep '^toolchain ' go.mod | cut -d' ' -f2) || echo "go$$(grep '^go ' go.mod | cut -d' ' -f2)")
+export GOTOOLCHAIN
+
 all: build
 
 ##@ General

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Operator for managing discovered clusters from OpenShift Cluster Manager
 
 ## Prerequisites
 
-- Go v1.25.0+
+- Go v1.25.8+
 - kubectl 1.21+
 - Operator-sdk v1.22.2
 - Docker

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -3,6 +3,9 @@ FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
 
 WORKDIR /workspace
 
+# Enable automatic Go toolchain downloads
+ENV GOTOOLCHAIN=auto
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -3,6 +3,9 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS plu
 
 WORKDIR /workspace
 
+# Enable automatic Go toolchain downloads
+ENV GOTOOLCHAIN=auto
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/build/Dockerfile.test.prow
+++ b/build/Dockerfile.test.prow
@@ -4,6 +4,9 @@ FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
 
 WORKDIR /workspace
 
+# Enable automatic Go toolchain downloads
+ENV GOTOOLCHAIN=auto
+
 COPY api/ api/
 COPY test/e2e/ test/e2e/
 COPY go.mod go.mod

--- a/build/Dockerfile.testserver.prow
+++ b/build/Dockerfile.testserver.prow
@@ -4,6 +4,9 @@ FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
 
 WORKDIR /workspace
 
+# Enable automatic Go toolchain downloads
+ENV GOTOOLCHAIN=auto
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/stolostron/discovery
 
-go 1.24.0
-
-toolchain go1.24.8
+go 1.25.8
 
 require (
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
# Description

Update Go version from 1.24.0 to 1.25.8 to address CVE-2026-25679.

## Related Issue

https://issues.redhat.com/browse/ACM-31123
https://issues.redhat.com/browse/ACM-32834

## Changes Made

- Updated go.mod to specify Go 1.25.8
- Removed toolchain directive to use default Go 1.25.8 toolchain
- Ran go mod tidy to update dependencies

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This update addresses CVE-2026-25679 in the Go stdlib net/url package.
CVE-2026-32280 still requires Go 1.25.9 which is not yet available.