### PR TITLE
Update Go to 1.25.8 to fix CVE-2026-25679

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'backplane-*'
 
 defaults:
   run:
@@ -18,7 +19,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.25.2'
+          - '1.25.8'
         kind:
           - 'latest'
     name: KinD tests

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -1,10 +1,5 @@
 name: KinD tests
 
-# NOTE: This workflow may fail during the "Unit Tests" step due to a known issue where
-# setup-envtest cannot authenticate with Google Cloud Storage (GCS 401 Unauthorized error)
-# when downloading Kubernetes test binaries. This is a CI infrastructure issue, not a code
-# issue. Local tests pass successfully with 'make test'.
-
 on:
   pull_request:
     branches:

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -1,5 +1,10 @@
 name: KinD tests
 
+# NOTE: This workflow may fail during the "Unit Tests" step due to a known issue where
+# setup-envtest cannot authenticate with Google Cloud Storage (GCS 401 Unauthorized error)
+# when downloading Kubernetes test binaries. This is a CI infrastructure issue, not a code
+# issue. Local tests pass successfully with 'make test'.
+
 on:
   pull_request:
     branches:

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Use toolchain from go.mod so Go uses a complete install (with covdata); avoids
+# "no such tool covdata" when auto-downloaded minimal toolchain is used (golang/go#75031).
+GOTOOLCHAIN ?= $(shell (grep '^toolchain ' go.mod | cut -d' ' -f2) || echo "go$$(grep '^go ' go.mod | cut -d' ' -f2)")
+export GOTOOLCHAIN
+
 all: build
 
 ##@ General
@@ -224,7 +229,7 @@ podman-catalog-push: ## Push a catalog image.
 
 .PHONY: test
 test: envtest ## Run unit tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --arch=amd64 --bin-dir=$(LOCALBIN) -p path)" go test `go list ./... | grep -v e2e` -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test `go list ./... | grep -v e2e` -coverprofile cover.out
 
 integration-tests: ## Run functional/integration tests
 	kubectl apply -f testserver/build/clusters.open-cluster-management.io_managedclusters.yaml
@@ -297,7 +302,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
 
 ############################################################
 # KinD CI section

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ SHELL = /usr/bin/env bash -o pipefail
 
 # Use toolchain from go.mod so Go uses a complete install (with covdata); avoids
 # "no such tool covdata" when auto-downloaded minimal toolchain is used (golang/go#75031).
-GOTOOLCHAIN ?= $(shell (grep '^toolchain ' go.mod | cut -d' ' -f2) || echo "go$$(grep '^go ' go.mod | cut -d' ' -f2)")
+GOTOOLCHAIN ?= $(shell awk '/^toolchain /{print $$2; found=1} /^go /{gover=$$2} END{if(found==0) print "go"gover}' go.mod)
 export GOTOOLCHAIN
 
 all: build
@@ -287,6 +287,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
+SETUP_ENVTEST_VERSION ?= v0.0.0-20260404204528-885e77d7d9fc
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -302,7 +303,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION)
 
 ############################################################
 # KinD CI section

--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
-SETUP_ENVTEST_VERSION ?= v0.0.0-20260404204528-885e77d7d9fc
+SETUP_ENVTEST_VERSION ?= release-0.17
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ podman-catalog-push: ## Push a catalog image.
 
 .PHONY: test
 test: envtest ## Run unit tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --arch=amd64 --bin-dir=$(LOCALBIN) -p path)" go test `go list ./... | grep -v e2e` -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --arch=amd64 --bin-dir=$(LOCALBIN) --use-deprecated-gcs=false -p path)" go test `go list ./... | grep -v e2e` -coverprofile cover.out
 
 integration-tests: ## Run functional/integration tests
 	kubectl apply -f testserver/build/clusters.open-cluster-management.io_managedclusters.yaml

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ podman-catalog-push: ## Push a catalog image.
 
 .PHONY: test
 test: envtest ## Run unit tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test `go list ./... | grep -v e2e` -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --arch=amd64 --bin-dir=$(LOCALBIN) -p path)" go test `go list ./... | grep -v e2e` -coverprofile cover.out
 
 integration-tests: ## Run functional/integration tests
 	kubectl apply -f testserver/build/clusters.open-cluster-management.io_managedclusters.yaml
@@ -302,7 +302,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 ############################################################
 # KinD CI section

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Operator for managing discovered clusters from OpenShift Cluster Manager
 
 ## Prerequisites
 
-- Go v1.25.0+
+- Go v1.25.8+
 - kubectl 1.21+
 - Operator-sdk v1.22.2
 - Docker

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -3,6 +3,9 @@ FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
 
 WORKDIR /workspace
 
+# Enable automatic Go toolchain downloads
+ENV GOTOOLCHAIN=auto
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -3,6 +3,9 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS plu
 
 WORKDIR /workspace
 
+# Enable automatic Go toolchain downloads
+ENV GOTOOLCHAIN=auto
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/build/Dockerfile.test.prow
+++ b/build/Dockerfile.test.prow
@@ -4,6 +4,9 @@ FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
 
 WORKDIR /workspace
 
+# Enable automatic Go toolchain downloads
+ENV GOTOOLCHAIN=auto
+
 COPY api/ api/
 COPY test/e2e/ test/e2e/
 COPY go.mod go.mod

--- a/build/Dockerfile.testserver.prow
+++ b/build/Dockerfile.testserver.prow
@@ -4,6 +4,9 @@ FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
 
 WORKDIR /workspace
 
+# Enable automatic Go toolchain downloads
+ENV GOTOOLCHAIN=auto
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -41,6 +41,10 @@ var signalHandlerContext context.Context
 var _ = BeforeSuite(func() {
 	log.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
+	// Disable WatchListClient feature to avoid cache sync timeouts with k8s.io v0.35.3
+	// See https://redhat.atlassian.net/browse/ACM-32357
+	Expect(os.Setenv("KUBE_FEATURE_WatchListClient", "false")).To(Succeed())
+
 	// SetupSignalHandler can only be called once, so we'll save the
 	// context it returns and reuse it each time we start a new
 	// manager.
@@ -114,4 +118,5 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	Expect(os.Unsetenv("UNIT_TEST")).To(Succeed())
+	Expect(os.Unsetenv("KUBE_FEATURE_WatchListClient")).To(Succeed())
 })

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/discovery
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
# Description

Update Go version from 1.25.0 to 1.25.8 to address CVE-2026-25679.

## Related Issue

https://issues.redhat.com/browse/ACM-31123
https://issues.redhat.com/browse/ACM-32834

## Changes Made

- Updated go.mod to specify Go 1.25.8
- Ran go mod tidy to update dependencies

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This update addresses CVE-2026-25679 in the Go stdlib net/url package.
CVE-2026-32280 still requires Go 1.25.9 which is not yet available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project Go/toolchain to 1.25.8 and exposed GOTOOLCHAIN in the Makefile.
  * Enabled automatic Go toolchain downloads in builder images.

* **CI**
  * CI workflow now runs on additional branch patterns and uses the updated Go matrix; added brief CI step guidance.

* **Tests**
  * Test suite sets and unsets KUBE_FEATURE_WatchListClient during setup/teardown.

* **Documentation**
  * README prerequisite updated to require Go v1.25.8+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->