### PR TITLE
ACM-30181 Inherit TLS profile from OpenShift APIServer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
-CONTROLLER_TOOLS_VERSION ?= v0.15.0
+CONTROLLER_TOOLS_VERSION ?= v0.19.0
 SETUP_ENVTEST_VERSION ?= release-0.17
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/config/crd/bases/discovery.open-cluster-management.io_discoveredclusters.yaml
+++ b/config/crd/bases/discovery.open-cluster-management.io_discoveredclusters.yaml
@@ -201,6 +201,9 @@ spec:
                     type:
                       description: Type is the type of the discovered cluster condition.
                       type: string
+                  required:
+                  - status
+                  - type
                   type: object
                 type: array
             type: object

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -91,6 +91,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - discovery.open-cluster-management.io
   resources:
   - discoveredclusters

--- a/controllers/discoveryconfig_controller.go
+++ b/controllers/discoveryconfig_controller.go
@@ -69,6 +69,7 @@ type DiscoveryConfigReconciler struct {
 // +kubebuilder:rbac:groups=discovery.open-cluster-management.io,resources=discoveryconfigs,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=discovery.open-cluster-management.io,resources=discoveryconfigs/finalizers,verbs=get;patch;update
 // +kubebuilder:rbac:groups=discovery.open-cluster-management.io,resources=discoveryconfigs/status,verbs=get;patch;update
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 
 func (r *DiscoveryConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logf.Info("Reconciling DiscoveryConfig", "Name", req.Name, "Namespace", req.Namespace)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
+	github.com/openshift/api v0.0.0-20240509232804-02500a65025d
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
+github.com/openshift/api v0.0.0-20240509232804-02500a65025d h1:yUiXRVTWb+me+83F2jKqtFM/CipmlLkuBGFh68E5ptk=
+github.com/openshift/api v0.0.0-20240509232804-02500a65025d/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
 github.com/pelletier/go-toml/v2 v2.3.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/main.go
+++ b/main.go
@@ -152,26 +152,9 @@ func main() {
 
 	// Get TLS configuration from OpenShift APIServer profile
 	tlsProfile, err := ocm.GetAPIServerTLSProfile(ctx, uncachedClient)
-	if err != nil {
-		setupLog.Error(err, "unable to get APIServer TLS profile, using default TLS 1.2")
-		// Continue with default if we can't get the profile
-		// Use Intermediate profile ciphers as secure default for TLS 1.2
-		tlsProfile = &configv1.TLSProfileSpec{
-			MinTLSVersion: configv1.VersionTLS12,
-			Ciphers: []string{
-				"TLS_AES_128_GCM_SHA256",
-				"TLS_AES_256_GCM_SHA384",
-				"TLS_CHACHA20_POLY1305_SHA256",
-				"ECDHE-ECDSA-AES128-GCM-SHA256",
-				"ECDHE-RSA-AES128-GCM-SHA256",
-				"ECDHE-ECDSA-AES256-GCM-SHA384",
-				"ECDHE-RSA-AES256-GCM-SHA384",
-				"ECDHE-ECDSA-CHACHA20-POLY1305",
-				"ECDHE-RSA-CHACHA20-POLY1305",
-				"DHE-RSA-AES128-GCM-SHA256",
-				"DHE-RSA-AES256-GCM-SHA384",
-			},
-		}
+	if err != nil || tlsProfile == nil {
+		setupLog.Error(err, "unable to get APIServer TLS profile, using default Intermediate profile")
+		tlsProfile = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
 	}
 
 	minTLSVersion := ocm.ConvertTLSVersion(tlsProfile.MinTLSVersion)

--- a/main.go
+++ b/main.go
@@ -37,10 +37,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"go.uber.org/zap/zapcore"
 	admissionregistration "k8s.io/api/admissionregistration/v1"
 	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -39,6 +40,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	admissionregistration "k8s.io/api/admissionregistration/v1"
 	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -64,6 +66,7 @@ import (
 	klusterletconfigv1alpha1 "github.com/stolostron/cluster-lifecycle-api/klusterletconfig/v1alpha1"
 	discoveryv1 "github.com/stolostron/discovery/api/v1"
 	"github.com/stolostron/discovery/controllers"
+	"github.com/stolostron/discovery/pkg/ocm"
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	corev1 "k8s.io/api/core/v1"
 	clusterapiv1 "open-cluster-management.io/api/cluster/v1"
@@ -136,6 +139,29 @@ func main() {
 	setupLog.Info(fmt.Sprintf("Go Version: %s", goruntime.Version()))
 	setupLog.Info(fmt.Sprintf("Go OS/Arch: %s/%s", goruntime.GOOS, goruntime.GOARCH))
 
+	// Create uncached client early for TLS profile fetching and other setup tasks
+	ctx := context.Background()
+	uncachedClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to create uncached client")
+		os.Exit(1)
+	}
+
+	// Get TLS configuration from OpenShift APIServer profile
+	tlsProfile, err := ocm.GetAPIServerTLSProfile(ctx, uncachedClient)
+	if err != nil {
+		setupLog.Error(err, "unable to get APIServer TLS profile, using default TLS 1.2")
+		// Continue with default if we can't get the profile
+		tlsProfile = &configv1.TLSProfileSpec{
+			MinTLSVersion: configv1.VersionTLS12,
+		}
+	}
+
+	minTLSVersion := ocm.ConvertTLSVersion(tlsProfile.MinTLSVersion)
+	setupLog.Info("Configuring webhook server TLS", "minTLSVersion", tlsProfile.MinTLSVersion, "numericValue", minTLSVersion)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -143,6 +169,9 @@ func main() {
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port: 9443,
+			TLSOpts: []func(*tls.Config){func(config *tls.Config) {
+				config.MinVersion = minTLSVersion
+			}},
 		}),
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
@@ -153,14 +182,6 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-
-	uncachedClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{
-		Scheme: scheme,
-	})
-	if err != nil {
-		setupLog.Error(err, "unable to create uncached client")
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -92,6 +92,7 @@ func init() {
 	utilruntime.Must(apixv1.AddToScheme(scheme))
 	utilruntime.Must(clusterapiv1.AddToScheme(scheme))
 	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(configv1.AddToScheme(scheme))
 	utilruntime.Must(discoveryv1.AddToScheme(scheme))
 	utilruntime.Must(agentv1.SchemeBuilder.AddToScheme(scheme))
 	utilruntime.Must(klusterletconfigv1alpha1.AddToScheme(scheme))

--- a/main.go
+++ b/main.go
@@ -155,13 +155,28 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "unable to get APIServer TLS profile, using default TLS 1.2")
 		// Continue with default if we can't get the profile
+		// Use Intermediate profile ciphers as secure default for TLS 1.2
 		tlsProfile = &configv1.TLSProfileSpec{
 			MinTLSVersion: configv1.VersionTLS12,
+			Ciphers: []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_CHACHA20_POLY1305_SHA256",
+				"ECDHE-ECDSA-AES128-GCM-SHA256",
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"ECDHE-ECDSA-AES256-GCM-SHA384",
+				"ECDHE-RSA-AES256-GCM-SHA384",
+				"ECDHE-ECDSA-CHACHA20-POLY1305",
+				"ECDHE-RSA-CHACHA20-POLY1305",
+				"DHE-RSA-AES128-GCM-SHA256",
+				"DHE-RSA-AES256-GCM-SHA384",
+			},
 		}
 	}
 
 	minTLSVersion := ocm.ConvertTLSVersion(tlsProfile.MinTLSVersion)
-	setupLog.Info("Configuring webhook server TLS", "minTLSVersion", tlsProfile.MinTLSVersion, "numericValue", minTLSVersion)
+	cipherSuites := ocm.ConvertCipherSuites(tlsProfile.Ciphers)
+	setupLog.Info("Configuring webhook server TLS", "minTLSVersion", tlsProfile.MinTLSVersion, "numericValue", minTLSVersion, "cipherCount", len(cipherSuites))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
@@ -172,6 +187,11 @@ func main() {
 			Port: 9443,
 			TLSOpts: []func(*tls.Config){func(config *tls.Config) {
 				config.MinVersion = minTLSVersion
+				// Only set CipherSuites for TLS ≤ 1.2
+				// TLS 1.3 cipher suites are managed automatically by Go
+				if minTLSVersion < tls.VersionTLS13 && len(cipherSuites) > 0 {
+					config.CipherSuites = cipherSuites
+				}
 			}},
 		}),
 		HealthProbeBindAddress: probeAddr,

--- a/pkg/ocm/tls_util.go
+++ b/pkg/ocm/tls_util.go
@@ -71,3 +71,51 @@ func ConvertTLSVersion(version configv1.TLSProtocolVersion) uint16 {
 		return tls.VersionTLS12
 	}
 }
+
+// ConvertCipherSuites converts OpenShift cipher suite names (OpenSSL format) to crypto/tls uint16 constants.
+// TLS 1.3 cipher suites are managed automatically by Go and cannot be configured, so they are filtered out.
+// Only returns cipher suites applicable to TLS ≤ 1.2.
+func ConvertCipherSuites(cipherNames []string) []uint16 {
+	// Mapping from OpenSSL cipher names to crypto/tls constants
+	// Only includes cipher suites that exist in Go's crypto/tls package
+	cipherMap := map[string]uint16{
+		// TLS 1.2 ECDHE ciphers (GCM and ChaCha20)
+		"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-RSA-AES256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-ECDSA-AES256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-RSA-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		"ECDHE-ECDSA-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+
+		// TLS 1.2 ECDHE ciphers (CBC)
+		"ECDHE-RSA-AES128-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-RSA-AES128-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-ECDSA-AES128-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-ECDSA-AES128-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-RSA-AES256-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"ECDHE-ECDSA-AES256-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+
+		// RSA ciphers
+		"AES128-GCM-SHA256": tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"AES256-GCM-SHA384": tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"AES128-SHA256":     tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"AES128-SHA":        tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"AES256-SHA":        tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"DES-CBC3-SHA":      tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	}
+
+	var result []uint16
+	for _, name := range cipherNames {
+		// Skip TLS 1.3 cipher suites (they start with TLS_ prefix and are auto-managed)
+		if len(name) > 4 && name[:4] == "TLS_" {
+			continue
+		}
+
+		if cipher, ok := cipherMap[name]; ok {
+			result = append(result, cipher)
+		}
+		// Silently skip unsupported cipher suites - Go may not support all OpenSSL ciphers
+	}
+
+	return result
+}

--- a/pkg/ocm/tls_util.go
+++ b/pkg/ocm/tls_util.go
@@ -1,0 +1,73 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package ocm
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"os"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// UnitTestEnvVar is the environment variable for unit testing.
+	UnitTestEnvVar = "UNIT_TEST"
+)
+
+// GetAPIServerTLSProfile retrieves the TLS security profile from the OpenShift APIServer resource.
+// Returns the TLSProfileSpec containing minTLSVersion and ciphers.
+// If no profile is set, returns the default Intermediate profile.
+func GetAPIServerTLSProfile(ctx context.Context, cl client.Client) (*configv1.TLSProfileSpec, error) {
+	// If running in unit test mode, return default Intermediate profile
+	if val, ok := os.LookupEnv(UnitTestEnvVar); ok && val == "true" {
+		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
+	}
+
+	apiServer := &configv1.APIServer{}
+	err := cl.Get(ctx, types.NamespacedName{Name: "cluster"}, apiServer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get APIServer resource: %w", err)
+	}
+
+	// If no TLS profile is set, use the default (Intermediate)
+	if apiServer.Spec.TLSSecurityProfile == nil {
+		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
+	}
+
+	profile := apiServer.Spec.TLSSecurityProfile
+
+	// For predefined profiles (Old, Intermediate, Modern), use the map
+	if profileSpec, ok := configv1.TLSProfiles[profile.Type]; ok {
+		return profileSpec, nil
+	}
+
+	// For custom profile, return the inline spec
+	if profile.Type == configv1.TLSProfileCustomType && profile.Custom != nil {
+		return &profile.Custom.TLSProfileSpec, nil
+	}
+
+	// Fallback to Intermediate if something unexpected
+	return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
+}
+
+// ConvertTLSVersion converts OpenShift TLSProtocolVersion string to crypto/tls uint16 constant.
+// Returns tls.VersionTLS12 as default if the version string is not recognized.
+func ConvertTLSVersion(version configv1.TLSProtocolVersion) uint16 {
+	switch version {
+	case configv1.VersionTLS10:
+		return tls.VersionTLS10
+	case configv1.VersionTLS11:
+		return tls.VersionTLS11
+	case configv1.VersionTLS12:
+		return tls.VersionTLS12
+	case configv1.VersionTLS13:
+		return tls.VersionTLS13
+	default:
+		// Default to TLS 1.2 for safety
+		return tls.VersionTLS12
+	}
+}


### PR DESCRIPTION
Removes hardcoded TLS 1.2 from webhook server. Fetches TLS profile dynamically from OpenShift APIServer resource. Defaults to Intermediate if not set. Updates controller-gen to v0.19.0 for Go 1.25 compatibility.

Related: ACM-30181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook servers now use OpenShift API server TLS profile with a TLS1.2-safe fallback.
  * CRD status condition objects now require `status` and `type`.

* **Chores**
  * Updated controller tooling version and added OpenShift API dependency.
  * Added permissions to read OpenShift API server configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->