### PR TITLE
[backplane-2.6][ACM-32848,ACM-32835] fix: upgrade Go to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/discovery
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
## Summary
Upgrade Go from 1.25.8 to 1.25.9 to fix critical CVEs:
- CVE-2026-32280: Go cert chain building DoS
- CVE-2026-32283: Go crypto/tls DoS via TLS 1.3 key updates

## Changes
- Updated `go.mod`: Go 1.25.8 → 1.25.9

## Related Issues
- ACM-33662: CVE-2026-32280 tracking task
- ACM-33661: CVE-2026-32283 tracking task

## Test Plan
- Go mod tidy completed successfully
- CI will run with Go 1.25.9

🤖 Generated with [Claude Code](https://claude.ai/code)