### PR TITLE
Add FIPS build flags to Konflux Dockerfile

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -14,7 +14,7 @@ COPY go.sum go.sum
 COPY . .
 
 # Build
-RUN CGO_ENABLED=1 go build -mod=readonly -o manager main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -mod=readonly -o manager main.go
 
 # Use ubi-minimal as minimal base image to package the manager binary
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
## Summary

- Adds `GOEXPERIMENT=strictfipsruntime` to the Konflux/RHTAP `build/Dockerfile.rhtap` build for the discovery-operator image (`CGO_ENABLED=1` was already set).
- Addresses [HYPBLD-844](https://redhat.atlassian.net/browse/HYPBLD-844) FIPS build flag requirements.

This pull request was created by Cursor.

## Test plan

- [ ] Verify Konflux/RHTAP pipeline build succeeds for discovery-operator on backplane-2.11
- [ ] Confirm built binaries link against FIPS crypto libraries as expected


Made with [Cursor](https://cursor.com)

[HYPBLD-844]: https://redhat.atlassian.net/browse/HYPBLD-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ