### PR TITLE
[ACM-30431] Replace webhook retry magic numbers with named constants

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,15 @@ import (
 
 const (
 	crdName = "discoveredclusters.discovery.open-cluster-management.io"
+
+	// webhookRetryDelay is the delay between retries when webhook operations fail.
+	// Set to 5 seconds to balance between quick recovery from transient failures
+	// and avoiding overwhelming the API server.
+	webhookRetryDelay = 5 * time.Second
+
+	// webhookMaxAttempts is the maximum number of retry attempts for webhook operations.
+	// With retryDelay=5s and maxAttempts=10, total retry time is ~50 seconds.
+	webhookMaxAttempts = 10
 )
 
 var (
@@ -261,8 +270,7 @@ func ensureWebhooks(k8sClient client.Client) error {
 	}
 	validatingWebhook := discoveryv1.ValidatingWebhook(deploymentNamespace)
 
-	maxAttempts := 10
-	for i := 0; i < maxAttempts; i++ {
+	for i := 0; i < webhookMaxAttempts; i++ {
 		setupLog.Info("Applying ValidatingWebhookConfiguration")
 
 		// Get reference to DiscoveredCluster CRD to set as owner of the webhook
@@ -271,7 +279,7 @@ func ensureWebhooks(k8sClient client.Client) error {
 		owner := &apixv1.CustomResourceDefinition{}
 		if err := k8sClient.Get(context.Background(), crdKey, owner); err != nil {
 			setupLog.Error(err, "Failed to get DiscoveredCluster CRD")
-			time.Sleep(5 * time.Second)
+			time.Sleep(webhookRetryDelay)
 			continue
 		}
 		validatingWebhook.SetOwnerReferences([]metav1.OwnerReference{
@@ -295,14 +303,14 @@ func ensureWebhooks(k8sClient client.Client) error {
 			err = k8sClient.Create(ctx, validatingWebhook)
 			if err != nil {
 				setupLog.Error(err, "Error creating validatingwebhookconfiguration")
-				time.Sleep(5 * time.Second)
+				time.Sleep(webhookRetryDelay)
 				continue
 			}
 			return nil
 
 		} else if err != nil {
 			setupLog.Error(err, "Error getting validatingwebhookconfiguration")
-			time.Sleep(5 * time.Second)
+			time.Sleep(webhookRetryDelay)
 			continue
 
 		} else if err == nil {
@@ -312,7 +320,7 @@ func ensureWebhooks(k8sClient client.Client) error {
 			err = k8sClient.Update(ctx, existingWebhook)
 			if err != nil {
 				setupLog.Error(err, "Error updating validatingwebhookconfiguration")
-				time.Sleep(5 * time.Second)
+				time.Sleep(webhookRetryDelay)
 				continue
 			}
 			return nil


### PR DESCRIPTION
# Description

Replace hardcoded webhook retry values (`maxAttempts=10`, `delay=5s`) with documented constants.

## Related Issue

https://redhat.atlassian.net/browse/ACM-30431

## Changes Made

**File: main.go**
- Added `webhookRetryDelay = 5 * time.Second` constant with documentation explaining retry strategy
- Added `webhookMaxAttempts = 10` constant documenting total retry time (~50 seconds)
- Replaced `maxAttempts := 10` local variable with constant
- Replaced all `time.Sleep(5 * time.Second)` calls with `time.Sleep(webhookRetryDelay)`

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

The documentation explains the retry strategy balances quick recovery from transient failures with avoiding overwhelming the API server. Total retry time is ~50 seconds (10 attempts × 5 seconds).

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.