### PR TITLE
fix: upgrade Go to 1.26.3 to address CVE-2026-33811

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.25.9'
+          - '1.26.3'
         kind:
           - 'latest'
     name: KinD tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Build the manager binary
-FROM golang:1.25 as builder
+FROM golang:1.26 as builder
 
 WORKDIR /workspace
 

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS plugin-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS plugin-builder
 
 WORKDIR /workspace
 

--- a/build/Dockerfile.test.prow
+++ b/build/Dockerfile.test.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/build/Dockerfile.testserver.prow
+++ b/build/Dockerfile.testserver.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/discovery
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/test/e2e/build/Dockerfile
+++ b/test/e2e/build/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /workspace
 

--- a/testserver/build/Dockerfile
+++ b/testserver/build/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM golang:1.25 as builder
+FROM golang:1.26 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary

- Bumps Go from 1.25.9 to 1.26.3 to fix CVE-2026-33811 — a denial of service vulnerability in `net.LookupCNAME` with the cgo DNS resolver (double-free on long CNAME response).
- Updates Konflux builder image from `rhel_9_1.25` to `rhel_9_1.26` (ships Go 1.26.3).
- Ref: https://pkg.go.dev/vuln/GO-2026-4981

## Test plan

- [x] `make build` passes
- [x] `make test` passes


🐨 Generated with Crush