### PR TITLE
ACM-35907: fix: upgrade Go to 1.26.3 to address CVE-2026-33811

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.25.7'
+          - '1.26.3'
         kind:
           - 'latest'
     name: KinD tests

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS plugin-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS plugin-builder
 
 WORKDIR /workspace
 

--- a/build/Dockerfile.test.prow
+++ b/build/Dockerfile.test.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/build/Dockerfile.testserver.prow
+++ b/build/Dockerfile.testserver.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/discovery
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/test/e2e/build/Dockerfile
+++ b/test/e2e/build/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM golang:1.24 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
### Summary
- Bumps Go from 1.25.9 to 1.26.3 and updates all builder images and CI workflows to use Go 1.26
- Related JIRA - [ACM-35907](https://redhat.atlassian.net/browse/ACM-35907)
- Ref - https://pkg.go.dev/vuln/GO-2026-4981

### Breaking Changes
- None. Go 1.26.3 is backward compatible.

### Test Plan
- [x] `go mod tidy` — no additional changes
- [x] `go build ./...` — succeeds

[ACM-35907]: https://redhat.atlassian.net/browse/ACM-35907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ