### PR TITLE
[ACM-37748] Add NetworkPolicy resources for discovery-operator

### DIFF
--- a/bundle/manifests/discovery-operator-allow-api-server_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/discovery-operator-allow-api-server_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,21 @@
+# Allow discovery-operator pods to reach the Kubernetes API server.
+# Port-based with empty 'to' because the API server runs on the host network
+# and cannot be selected via pod/namespace selectors. Covers both standard (443)
+# and common alternate (6443) API server ports.
+# Also covers egress to external HTTPS endpoints (sso.redhat.com, api.openshift.com).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: discovery-operator-allow-api-server
+spec:
+  podSelector:
+    matchLabels:
+      app: discovery-operator
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  policyTypes:
+  - Egress

--- a/bundle/manifests/discovery-operator-allow-dns_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/discovery-operator-allow-dns_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,23 @@
+# Allow discovery-operator pods to reach cluster DNS for name resolution.
+# Port-based with no namespace selector to support both OpenShift (openshift-dns)
+# and vanilla Kubernetes (kube-system) DNS deployments.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: discovery-operator-allow-dns
+spec:
+  podSelector:
+    matchLabels:
+      app: discovery-operator
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 5353
+    - protocol: UDP
+      port: 5353
+  policyTypes:
+  - Egress

--- a/bundle/manifests/discovery-operator-allow-metrics_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/discovery-operator-allow-metrics_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,16 @@
+# Allow ingress to the discovery-operator metrics endpoint (port 8080)
+# from any pod in the cluster for Prometheus scraping.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: discovery-operator-allow-metrics
+spec:
+  podSelector:
+    matchLabels:
+      app: discovery-operator
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8080
+  policyTypes:
+  - Ingress

--- a/bundle/manifests/discovery-operator-allow-webhook_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/discovery-operator-allow-webhook_networking.k8s.io_v1_networkpolicy.yaml
@@ -14,6 +14,7 @@ spec:
     - namespaceSelector:
         matchLabels:
           policy-group.network.openshift.io/host-network: ""
+      podSelector: {}
     ports:
     - protocol: TCP
       port: 9443

--- a/bundle/manifests/discovery-operator-allow-webhook_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/discovery-operator-allow-webhook_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,21 @@
+# Allow ingress to the discovery-operator webhook server (port 9443).
+# Webhook calls originate from the API server which runs on the host network,
+# so we use the special host-network namespace selector.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: discovery-operator-allow-webhook
+spec:
+  podSelector:
+    matchLabels:
+      app: discovery-operator
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/host-network: ""
+    ports:
+    - protocol: TCP
+      port: 9443
+  policyTypes:
+  - Ingress

--- a/bundle/manifests/discovery-operator-default-deny_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/discovery-operator-default-deny_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,14 @@
+# Default deny for discovery-operator pods.
+# Label-scoped: only affects pods with app: discovery-operator.
+# Does not impact other pods in the namespace (safe for shared/OLM namespaces).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: discovery-operator-default-deny
+spec:
+  podSelector:
+    matchLabels:
+      app: discovery-operator
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
# Description

Add label-scoped NetworkPolicy resources to restrict network traffic for discovery-operator pods following the principle of least privilege. Policies are designed for OLM-based deployment in potentially shared namespaces.

## Related Issue

- [ACM-37748](https://redhat.atlassian.net/browse/ACM-37748) — Develop network policies for Installer components
- Related test task: [ACM-31166](https://redhat.atlassian.net/browse/ACM-31166)

## Changes Made

Five NetworkPolicy resources added to `bundle/manifests/`:

| Policy | Type | Description |
|--------|------|-------------|
| `discovery-operator-default-deny` | Deny | Label-scoped default deny (ingress + egress) for `app: discovery-operator` pods |
| `discovery-operator-allow-dns` | Egress | DNS resolution on ports 53 and 5353 (TCP/UDP), no namespace selector for cross-platform compatibility |
| `discovery-operator-allow-api-server` | Egress | Port-based (443 + 6443) for Kubernetes API server and external HTTPS endpoints (sso.redhat.com, api.openshift.com) |
| `discovery-operator-allow-metrics` | Ingress | Port 8080 for Prometheus metrics scraping |
| `discovery-operator-allow-webhook` | Ingress | Port 9443 from host-network pods for ValidatingWebhookConfiguration calls |

### Design Decisions

- **Label-scoped deny** (not namespace-wide): Safe for shared/OLM namespaces per [Network Policy best practices](https://docs.google.com/document/d/1pLnmFGclSbCwPK24mEnJLMEqHLGKP5XjfMK6gE0mx1k/) for layered products
- **No namespace selector on DNS**: Supports both OpenShift (`openshift-dns`) and vanilla Kubernetes (`kube-system`)
- **Port-based API server egress**: API server runs on host network, can't be selected via pod/namespace selectors. Port-based approach (443 + 6443) with empty `to` matches backplane-operator pattern
- **Health probes (8081) omitted**: Not blocked by NetworkPolicy per Kubernetes spec
- **Separate policy files**: Each policy has a single concern for clarity and independent management

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- Analyzed backplane-operator's existing NetworkPolicies for pattern alignment
- Policies are additive — no way to deny once allowed per Kubernetes NetworkPolicy spec
- External HTTPS egress (sso.redhat.com, api.openshift.com) is covered by the API server egress rule since both use port 443

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACM-37748]: https://redhat.atlassian.net/browse/ACM-37748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-31166]: https://redhat.atlassian.net/browse/ACM-31166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added default-deny network protection for the Discovery Operator.
  * Allowed required outbound connections to the Kubernetes API server and cluster DNS.
  * Enabled authorized webhook traffic on port 9443.
  * Allowed metrics collection on port 8080 for monitoring.
  * Restricted inbound and outbound traffic to explicitly permitted protocols and ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->